### PR TITLE
Fix compile errors and add quick start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This method can also be used inside an Activity, when the use of an external bas
 # Developer quick start
 
 In order to start developing and testing the library:
-* Have Android Studio installed with your project open and ready
+* Have Android Studio installed and open the project with it
 * Connect a compatible android device via USB, it should then show up in Android Studio's device manager
 * Run the app with the android device selected
 

--- a/README.md
+++ b/README.md
@@ -169,3 +169,14 @@ These can be found as static strings inside the `ScannerServiceApi` interface.
 This often happens when dealing with UI frameworks which have their own lifecycle handling such as Cordova. The programmer does not directly write activities deriving from Activity, but has access to the underlying Activity object used by the framework. In this case, it is just a matter of binding to the service like above, and then call `ScannerServiceApi.takeForegroundControl(Activity, ForegroundScannerClient)` (this internally calls `registerClient` too). This will register the activity as having foreground control, and full foreground scanner access will be available.
 
 This method can also be used inside an Activity, when the use of an external base class for an Activity is not possible (for example when there already is a base class, or when using `AppCompatActivity` is not desired). This is exactly what `ScannerCompatActivity` does - it simply binds to the service.
+
+# Developer quick start
+
+In order to start developing and testing the library:
+* Have Android Studio installed with your project open and ready
+* Connect a compatible android device via USB, it should then show up in Android Studio's device manager
+* Run the app with the android device selected
+
+In case the android device is not detected by Android Studio:
+* Make sure the device is in developer mode and has USB Debugging enabled
+* Make sure the USB cable supports data transfer (some cables only support charging)

--- a/demoscannerapp/build.gradle
+++ b/demoscannerapp/build.gradle
@@ -2,10 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-
+    lintOptions {
+        disable 'ExpiredTargetSdkVersion'
+    }
     defaultConfig {
         applicationId "com.enioka.scanner.demoscannerapp"
         minSdkVersion 19
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/demoscannerapp/src/main/AndroidManifest.xml
+++ b/demoscannerapp/src/main/AndroidManifest.xml
@@ -18,9 +18,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".slip.SlipScanActivity"
-            android:screenOrientation="landscape" />
     </application>
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/enioka_scan/build.gradle
+++ b/enioka_scan/build.gradle
@@ -2,8 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    lintOptions {
+        disable 'ExpiredTargetSdkVersion'
+    }
     defaultConfig {
         minSdkVersion 19
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 28
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/enioka_scan_honeywell/build.gradle
+++ b/enioka_scan_honeywell/build.gradle
@@ -2,8 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    lintOptions {
+        disable 'ExpiredTargetSdkVersion'
+    }
     defaultConfig {
         minSdkVersion 19
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 28
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/enioka_scan_koamtac/build.gradle
+++ b/enioka_scan_koamtac/build.gradle
@@ -2,8 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    lintOptions {
+        disable 'ExpiredTargetSdkVersion'
+    }
     defaultConfig {
         minSdkVersion 19
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 28
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/enioka_scan_m3/build.gradle
+++ b/enioka_scan_m3/build.gradle
@@ -2,8 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    lintOptions {
+        disable 'ExpiredTargetSdkVersion'
+    }
     defaultConfig {
         minSdkVersion 19
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 28
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/enioka_scan_zebra/build.gradle
+++ b/enioka_scan_zebra/build.gradle
@@ -2,8 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+    lintOptions {
+        disable 'ExpiredTargetSdkVersion'
+    }
     defaultConfig {
         minSdkVersion 19
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 28
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
Resolves #46 

* Remove mentions of non-existent classes
* Disable lint errors regarding outdated target SDKs
* Add developer quick start section in the README