### PR TITLE
OLD: #36 - Add helpers to centralize jumps to ui-thread, remove individual sdk uses

### DIFF
--- a/enioka_scan/src/main/AndroidManifest.xml
+++ b/enioka_scan/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
                 <action android:name="com.enioka.scan.PROVIDE_SPP_SCANNER" />
             </intent-filter>
         </service>
-<!--
+
         <service
             android:name=".sdk.zebraoss.ZebraOssSppScannerProvider"
             android:description="@string/service_description"
@@ -42,7 +42,7 @@
                 <action android:name="com.enioka.scan.PROVIDE_SPP_SCANNER" />
             </intent-filter>
         </service>
--->
+
         <!-- DISABLED: never tested, so rather incomplete and likely buggy.
         <service
             android:name=".sdk.postech.PostechSppScannerProvider"
@@ -55,7 +55,7 @@
         </service> -->
 
         <!-- Other scanner providers -->
-<!--
+
         <service
             android:name=".sdk.hid.GenericHidProvider"
             android:description="@string/service_description"
@@ -98,7 +98,7 @@
                 <action android:name="com.enioka.scan.PROVIDE_SCANNER" />
             </intent-filter>
         </service>
--->
+
         <service
             android:name=".bt.manager.SerialBtScannerProvider"
             android:description="@string/service_description"

--- a/enioka_scan/src/main/AndroidManifest.xml
+++ b/enioka_scan/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
                 <action android:name="com.enioka.scan.PROVIDE_SPP_SCANNER" />
             </intent-filter>
         </service>
-
+<!--
         <service
             android:name=".sdk.zebraoss.ZebraOssSppScannerProvider"
             android:description="@string/service_description"
@@ -42,7 +42,7 @@
                 <action android:name="com.enioka.scan.PROVIDE_SPP_SCANNER" />
             </intent-filter>
         </service>
-
+-->
         <!-- DISABLED: never tested, so rather incomplete and likely buggy.
         <service
             android:name=".sdk.postech.PostechSppScannerProvider"
@@ -55,6 +55,7 @@
         </service> -->
 
         <!-- Other scanner providers -->
+<!--
         <service
             android:name=".sdk.hid.GenericHidProvider"
             android:description="@string/service_description"
@@ -97,7 +98,7 @@
                 <action android:name="com.enioka.scan.PROVIDE_SCANNER" />
             </intent-filter>
         </service>
-
+-->
         <service
             android:name=".bt.manager.SerialBtScannerProvider"
             android:description="@string/service_description"

--- a/enioka_scan/src/main/java/com/enioka/scanner/LaserScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/LaserScanner.java
@@ -19,7 +19,6 @@ import com.enioka.scanner.api.ScannerSearchOptions;
 import com.enioka.scanner.helpers.BtScannerConnectionRegistry;
 import com.enioka.scanner.helpers.ProviderServiceHolder;
 import com.enioka.scanner.helpers.ProviderServiceMeta;
-import com.enioka.scanner.helpers.ScannerConnectionHandlerProxy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -223,7 +222,8 @@ public final class LaserScanner {
     }
 
     private static void startLaserSearchInProviders(final Context ctx, ScannerConnectionHandler handler, final ScannerSearchOptions options) {
-        final ScannerConnectionHandler handlerProxy = new ScannerConnectionHandlerProxy(handler);
+        // Handler is now directly passed as a proxy
+        //final ScannerConnectionHandler handlerProxy = new ScannerConnectionHandlerProxy(handler);
 
         if (options.useBlueTooth) {
             btRegistry.register(ctx);
@@ -232,8 +232,8 @@ public final class LaserScanner {
         // Trivial
         if (providerServices.isEmpty()) {
             Log.i(LOG_TAG, "There are no laser scanners available at all");
-            handlerProxy.noScannerAvailable();
-            handlerProxy.endOfScannerSearch();
+            handler.noScannerAvailable();
+            handler.endOfScannerSearch();
             return;
         }
 
@@ -253,7 +253,7 @@ public final class LaserScanner {
         }
 
         providersHavingAnswered.drainPermits();
-        final ScannerProvider.ProviderCallback providerCallback = getProviderCallback(handlerProxy, options);
+        final ScannerProvider.ProviderCallback providerCallback = getProviderCallback(handler, options);
 
         // Interrogate all providers, grouped by priority. (higher priority comes first).
         Log.i(LOG_TAG, "There are " + providersExpectedToAnswerCount + " providers which are going to be invoked for fresh laser scanners");

--- a/enioka_scan/src/main/java/com/enioka/scanner/LaserScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/LaserScanner.java
@@ -12,13 +12,13 @@ import android.os.IBinder;
 import android.util.Log;
 
 import com.enioka.scanner.api.Scanner;
-import com.enioka.scanner.api.ScannerConnectionHandler;
 import com.enioka.scanner.api.ScannerProvider;
 import com.enioka.scanner.api.ScannerProviderBinder;
 import com.enioka.scanner.api.ScannerSearchOptions;
 import com.enioka.scanner.helpers.BtScannerConnectionRegistry;
 import com.enioka.scanner.helpers.ProviderServiceHolder;
 import com.enioka.scanner.helpers.ProviderServiceMeta;
+import com.enioka.scanner.helpers.ScannerConnectionHandlerProxy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -191,7 +191,7 @@ public final class LaserScanner {
      * @param handler the callback.
      * @param options parameters for scanner search.
      */
-    public static void getLaserScanner(final Context ctx, final ScannerConnectionHandler handler, final ScannerSearchOptions options) {
+    public static void getLaserScanner(final Context ctx, final ScannerConnectionHandlerProxy handler, final ScannerSearchOptions options) {
         if (providerServices.isEmpty()) {
             getProviders(ctx, new OnProvidersDiscovered() {
                 @Override
@@ -221,10 +221,7 @@ public final class LaserScanner {
         return true;
     }
 
-    private static void startLaserSearchInProviders(final Context ctx, ScannerConnectionHandler handler, final ScannerSearchOptions options) {
-        // Handler is now directly passed as a proxy
-        //final ScannerConnectionHandler handlerProxy = new ScannerConnectionHandlerProxy(handler);
-
+    private static void startLaserSearchInProviders(final Context ctx, ScannerConnectionHandlerProxy handler, final ScannerSearchOptions options) {
         if (options.useBlueTooth) {
             btRegistry.register(ctx);
         }
@@ -300,7 +297,7 @@ public final class LaserScanner {
         }
     }
 
-    private static ScannerProvider.ProviderCallback getProviderCallback(final ScannerConnectionHandler handler, final ScannerSearchOptions options) {
+    private static ScannerProvider.ProviderCallback getProviderCallback(final ScannerConnectionHandlerProxy handler, final ScannerSearchOptions options) {
         return new ScannerProvider.ProviderCallback() {
             @Override
             public void onScannerCreated(String providerKey, String scannerKey, Scanner s) {

--- a/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
@@ -183,7 +183,7 @@ public class ScannerCompatActivity extends AppCompatActivity implements Foregrou
         Intent intent = new Intent(this, ScannerService.class);
         intent.putExtra(ScannerServiceApi.EXTRA_BT_ALLOW_BT_BOOLEAN, useBluetooth);
         intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOW_INITIAL_SEARCH_BOOLEAN, useBluetooth);
-        intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOWED_PROVIDERS_STRING_ARRAY, new String[]{"BtSppSdk"});
+        //intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOWED_PROVIDERS_STRING_ARRAY, new String[]{"BtSppSdk"});
         //intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOW_PAIRING_FLOW_BOOLEAN, true);
         intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_EXCLUDED_PROVIDERS_STRING_ARRAY, new String[]{"BtZebraProvider"});
         bindService(intent, connection, Context.BIND_AUTO_CREATE);

--- a/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/activities/ScannerCompatActivity.java
@@ -183,7 +183,7 @@ public class ScannerCompatActivity extends AppCompatActivity implements Foregrou
         Intent intent = new Intent(this, ScannerService.class);
         intent.putExtra(ScannerServiceApi.EXTRA_BT_ALLOW_BT_BOOLEAN, useBluetooth);
         intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOW_INITIAL_SEARCH_BOOLEAN, useBluetooth);
-        //intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOWED_PROVIDERS_STRING_ARRAY, new String[]{"BtSppSdk"});
+        intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOWED_PROVIDERS_STRING_ARRAY, new String[]{"BtSppSdk"});
         //intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_ALLOW_PAIRING_FLOW_BOOLEAN, true);
         intent.putExtra(ScannerServiceApi.EXTRA_SEARCH_EXCLUDED_PROVIDERS_STRING_ARRAY, new String[]{"BtZebraProvider"});
         bindService(intent, connection, Context.BIND_AUTO_CREATE);

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/Scanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/Scanner.java
@@ -1,6 +1,7 @@
 package com.enioka.scanner.api;
 
 import com.enioka.scanner.data.Barcode;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
 
 import java.util.List;
 import java.util.Map;
@@ -93,7 +94,7 @@ public interface Scanner {
      *
      * @param cb a callback to call when data is read.
      */
-    void setDataCallBack(ScannerDataCallback cb);
+    void setDataCallBack(ScannerDataCallbackProxy cb);
 
     /**
      * Disconnect scanner from the App (the app does not need the scanner anymore)

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerBackground.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerBackground.java
@@ -1,7 +1,10 @@
 package com.enioka.scanner.api;
 
-import android.app.Activity;
 import android.content.Context;
+
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 
 /**
  * A Scanner which does not need anything from the foreground.
@@ -10,6 +13,6 @@ public interface ScannerBackground extends Scanner {
     /**
      * Called once per application launch.
      */
-    void initialize(Context applicationContext, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode);
+    void initialize(Context applicationContext, ScannerInitCallbackProxy initCallback, ScannerDataCallbackProxy dataCallback, ScannerStatusCallbackProxy statusCallback, Mode mode);
 
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerForeground.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerForeground.java
@@ -10,8 +10,8 @@ public interface ScannerForeground extends Scanner {
      * Called once per application launch.
      *
      * @param ctx The application
-     * @param cb1 a callback to call when data is read.
+     * @param dataCallback a callback to call when data is read.
      */
-    void initialize(Activity ctx, ScannerInitCallback cb0, ScannerDataCallback cb1, ScannerStatusCallback cb2, Mode mode);
+    void initialize(Activity ctx, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode);
 
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerForeground.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerForeground.java
@@ -2,6 +2,10 @@ package com.enioka.scanner.api;
 
 import android.app.Activity;
 
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
+
 /**
  * A Scanner which can only work in relation with an Activity.
  */
@@ -12,6 +16,6 @@ public interface ScannerForeground extends Scanner {
      * @param ctx The application
      * @param dataCallback a callback to call when data is read.
      */
-    void initialize(Activity ctx, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode);
+    void initialize(Activity ctx, ScannerInitCallbackProxy initCallback, ScannerDataCallbackProxy dataCallback, ScannerStatusCallbackProxy statusCallback, Mode mode);
 
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerConnectionHandlerProxy.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerConnectionHandlerProxy.java
@@ -10,52 +10,30 @@ import com.enioka.scanner.api.ScannerConnectionHandler;
  * A helper to put all interactions with the caller on the UI thread.
  */
 public class ScannerConnectionHandlerProxy implements ScannerConnectionHandler {
-    private final Handler handler;
+    private final Handler uiHandler = new Handler(Looper.getMainLooper());
     private final ScannerConnectionHandler encapsulatedHandler;
 
     public ScannerConnectionHandlerProxy(ScannerConnectionHandler encapsulatedHandler) {
-        Looper looper = Looper.myLooper() != null ? Looper.myLooper() : Looper.getMainLooper();
-        handler = new Handler(looper);
         this.encapsulatedHandler = encapsulatedHandler;
     }
 
     @Override
     public void scannerConnectionProgress(final String providerKey, final String scannerKey, final String message) {
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                encapsulatedHandler.scannerConnectionProgress(providerKey, scannerKey, message);
-            }
-        });
+        uiHandler.post(() -> encapsulatedHandler.scannerConnectionProgress(providerKey, scannerKey, message));
     }
 
     @Override
     public void scannerCreated(final String providerKey, final String scannerKey, final Scanner s) {
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                encapsulatedHandler.scannerCreated(providerKey, scannerKey, s);
-            }
-        });
+        uiHandler.post(() -> encapsulatedHandler.scannerCreated(providerKey, scannerKey, s));
     }
 
     @Override
     public void noScannerAvailable() {
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                encapsulatedHandler.noScannerAvailable();
-            }
-        });
+        uiHandler.post(encapsulatedHandler::noScannerAvailable);
     }
 
     @Override
     public void endOfScannerSearch() {
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                encapsulatedHandler.endOfScannerSearch();
-            }
-        });
+        uiHandler.post(encapsulatedHandler::endOfScannerSearch);
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerDataCallbackProxy.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerDataCallbackProxy.java
@@ -4,7 +4,6 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.enioka.scanner.api.Scanner;
-import com.enioka.scanner.api.ScannerConnectionHandler;
 import com.enioka.scanner.data.Barcode;
 
 import java.util.List;
@@ -13,22 +12,15 @@ import java.util.List;
  * A helper to put all interactions with the caller on the UI thread.
  */
 public class ScannerDataCallbackProxy implements Scanner.ScannerDataCallback {
-    private final Handler handler;
+    private final Handler uiHandler = new Handler(Looper.getMainLooper());
     private final Scanner.ScannerDataCallback encapsulatedHandler;
 
     public ScannerDataCallbackProxy(Scanner.ScannerDataCallback encapsulatedHandler) {
-        Looper looper = Looper.myLooper() != null ? Looper.myLooper() : Looper.getMainLooper();
-        handler = new Handler(looper);
         this.encapsulatedHandler = encapsulatedHandler;
     }
 
     @Override
     public void onData(final Scanner s, final List<Barcode> data) {
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                encapsulatedHandler.onData(s, data);
-            }
-        });
+        uiHandler.post(() -> encapsulatedHandler.onData(s, data));
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerInitCallbackProxy.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerInitCallbackProxy.java
@@ -1,0 +1,28 @@
+package com.enioka.scanner.helpers;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import com.enioka.scanner.api.Scanner;
+
+/**
+ * A helper to put all interactions with the caller on the UI thread.
+ */
+public class ScannerInitCallbackProxy implements Scanner.ScannerInitCallback{
+    private final Handler uiHandler = new Handler(Looper.getMainLooper());
+    private final Scanner.ScannerInitCallback encapsulatedHandler;
+
+    public ScannerInitCallbackProxy(Scanner.ScannerInitCallback encapsulatedHandler) {
+        this.encapsulatedHandler = encapsulatedHandler;
+    }
+
+    @Override
+    public void onConnectionSuccessful(Scanner s) {
+        uiHandler.post(() -> encapsulatedHandler.onConnectionSuccessful(s));
+    }
+
+    @Override
+    public void onConnectionFailure(Scanner s) {
+        uiHandler.post(() -> encapsulatedHandler.onConnectionFailure(s));
+    }
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerSppStatusCallbackProxy.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerSppStatusCallbackProxy.java
@@ -1,0 +1,33 @@
+package com.enioka.scanner.helpers;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import com.enioka.scanner.bt.api.Scanner;
+
+/**
+ * A helper to put all interactions with the caller on the UI thread.
+ */
+public class ScannerSppStatusCallbackProxy implements  Scanner.SppScannerStatusCallback {
+    private final Handler uiHandler = new Handler(Looper.getMainLooper());
+    private final Scanner.SppScannerStatusCallback encapsulatedHandler;
+
+    public ScannerSppStatusCallbackProxy(Scanner.SppScannerStatusCallback encapsulatedHandler) {
+        this.encapsulatedHandler = encapsulatedHandler;
+    }
+
+    @Override
+    public void onScannerConnected() {
+        uiHandler.post(encapsulatedHandler::onScannerConnected);
+    }
+
+    @Override
+    public void onScannerReconnecting() {
+        uiHandler.post(encapsulatedHandler::onScannerReconnecting);
+    }
+
+    @Override
+    public void onScannerDisconnected() {
+        uiHandler.post(encapsulatedHandler::onScannerDisconnected);
+    }
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerStatusCallbackProxy.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/helpers/ScannerStatusCallbackProxy.java
@@ -1,0 +1,33 @@
+package com.enioka.scanner.helpers;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import com.enioka.scanner.api.Scanner;
+
+/**
+ * A helper to put all interactions with the caller on the UI thread.
+ */
+public class ScannerStatusCallbackProxy implements Scanner.ScannerStatusCallback {
+    private final Handler uiHandler = new Handler(Looper.getMainLooper());
+    private final Scanner.ScannerStatusCallback encapsulatedHandler;
+
+    public ScannerStatusCallbackProxy(Scanner.ScannerStatusCallback encapsulatedHandler) {
+        this.encapsulatedHandler = encapsulatedHandler;
+    }
+
+    @Override
+    public void onStatusChanged(String newStatus) {
+        uiHandler.post(() -> encapsulatedHandler.onStatusChanged(newStatus));
+    }
+
+    @Override
+    public void onScannerReconnecting(Scanner s) {
+        uiHandler.post(() -> encapsulatedHandler.onScannerReconnecting(s));
+    }
+
+    @Override
+    public void onScannerDisconnected(Scanner s) {
+        uiHandler.post(() -> encapsulatedHandler.onScannerDisconnected(s));
+    }
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/helpers/intent/IntentScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/helpers/intent/IntentScanner.java
@@ -12,11 +12,13 @@ import com.enioka.scanner.api.Scanner;
 import com.enioka.scanner.api.ScannerBackground;
 import com.enioka.scanner.camera.CameraBarcodeScanView;
 import com.enioka.scanner.data.BarcodeType;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -50,13 +52,13 @@ public abstract class IntentScanner<BarcodeTypeClass> extends BroadcastReceiver 
     // LIFE CYCLE
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    protected Scanner.ScannerDataCallback dataCb = null;
-    protected Scanner.ScannerStatusCallback statusCb = null;
+    protected ScannerDataCallbackProxy dataCb = null;
+    protected ScannerStatusCallbackProxy statusCb = null;
     protected Scanner.Mode mode;
 
 
     @Override
-    public void initialize(Context ctx, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode) {
+    public void initialize(Context ctx, ScannerInitCallbackProxy initCallback, ScannerDataCallbackProxy dataCallback, ScannerStatusCallbackProxy statusCallback, Mode mode) {
         this.dataCb = dataCallback;
         this.statusCb = statusCallback;
         this.mode = mode;
@@ -104,7 +106,7 @@ public abstract class IntentScanner<BarcodeTypeClass> extends BroadcastReceiver 
     }
 
     @Override
-    public void setDataCallBack(ScannerDataCallback cb) {
+    public void setDataCallBack(ScannerDataCallbackProxy cb) {
         this.dataCb = cb;
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewScanner.java
@@ -38,9 +38,9 @@ public class CameraBarcodeScanViewScanner implements ScannerForeground, CameraBa
     }
 
     @Override
-    public void initialize(Activity ctx, ScannerInitCallback cb0, ScannerDataCallback cb1, ScannerStatusCallback cb2, Mode mode) {
+    public void initialize(Activity ctx, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode) {
         // Do nothing. The camera view implementation is special, as it is built directly and not through the LaserScanner.
-        cb0.onConnectionSuccessful(this);
+        initCallback.onConnectionSuccessful(this);
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/camera/CameraBarcodeScanViewScanner.java
@@ -8,6 +8,9 @@ import com.enioka.scanner.api.ScannerForeground;
 import com.enioka.scanner.camera.CameraBarcodeScanView;
 import com.enioka.scanner.data.Barcode;
 import com.enioka.scanner.data.BarcodeType;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,13 +41,13 @@ public class CameraBarcodeScanViewScanner implements ScannerForeground, CameraBa
     }
 
     @Override
-    public void initialize(Activity ctx, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode) {
+    public void initialize(Activity ctx, ScannerInitCallbackProxy initCallback, ScannerDataCallbackProxy dataCallback, ScannerStatusCallbackProxy statusCallback, Mode mode) {
         // Do nothing. The camera view implementation is special, as it is built directly and not through the LaserScanner.
         initCallback.onConnectionSuccessful(this);
     }
 
     @Override
-    public void setDataCallBack(ScannerDataCallback cb) {
+    public void setDataCallBack(ScannerDataCallbackProxy cb) {
         //
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
@@ -8,6 +8,9 @@ import com.enioka.scanner.api.ScannerBackground;
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 import com.enioka.scanner.bt.api.Scanner;
 import com.enioka.scanner.data.Barcode;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 import com.enioka.scanner.sdk.generalscan.commands.Bell;
 import com.enioka.scanner.sdk.generalscan.commands.CloseRead;
 import com.enioka.scanner.sdk.generalscan.commands.EnableBarcodeSuffix;
@@ -38,7 +41,7 @@ class GsSppScanner implements ScannerBackground {
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void initialize(final Context applicationContext, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
+    public void initialize(final Context applicationContext, ScannerInitCallbackProxy initCallback, ScannerDataCallbackProxy dataCallback, final ScannerStatusCallbackProxy statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
@@ -89,7 +92,7 @@ class GsSppScanner implements ScannerBackground {
     }
 
     @Override
-    public void setDataCallBack(ScannerDataCallback cb) {
+    public void setDataCallBack(ScannerDataCallbackProxy cb) {
         this.dataCallback = cb;
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
@@ -1,7 +1,6 @@
 package com.enioka.scanner.sdk.generalscan;
 
 import android.content.Context;
-import android.os.Handler;
 
 import com.enioka.scanner.R;
 import com.enioka.scanner.api.Color;
@@ -42,8 +41,6 @@ class GsSppScanner implements ScannerBackground {
     public void initialize(final Context applicationContext, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
-        final Handler uiHandler = new Handler(applicationContext.getMainLooper());
-
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
             public void onScannerConnected() {
@@ -68,12 +65,7 @@ class GsSppScanner implements ScannerBackground {
             public void onSuccess(final Barcode data) {
                 final List<Barcode> res = new ArrayList<>(1);
                 res.add(data);
-                uiHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        GsSppScanner.this.dataCallback.onData(GsSppScanner.this, res);
-                    }
-                });
+                GsSppScanner.this.dataCallback.onData(GsSppScanner.this, res);
 
             }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidScanner.java
@@ -25,14 +25,14 @@ public class GenericHidScanner implements ScannerForeground {
     private ScannerDataCallback dataCb;
 
     @Override
-    public void initialize(Activity ctx, ScannerInitCallback cb0, final ScannerDataCallback cb1, ScannerStatusCallback cb2, Mode mode) {
-        this.dataCb = cb1;
+    public void initialize(Activity ctx, ScannerInitCallback initCallback, final ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode) {
+        this.dataCb = dataCallback;
 
         // Register an OnKeyListener onto the Activity root view, if any.
         View rootParentView = ctx.findViewById(android.R.id.content);
 
         if (rootParentView == null) {
-            cb0.onConnectionFailure(this);
+            initCallback.onConnectionFailure(this);
             Log.w(LOG_TAG, "Tried to listen to a HID but no view is available - only views allow to listen to key presses");
         }
 
@@ -69,7 +69,7 @@ public class GenericHidScanner implements ScannerForeground {
         });
 
         Log.i(LOG_TAG, "HID scanner initialized");
-        cb0.onConnectionSuccessful(this);
+        initCallback.onConnectionSuccessful(this);
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidScanner.java
@@ -7,10 +7,12 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.enioka.scanner.api.Color;
-import com.enioka.scanner.api.Scanner;
 import com.enioka.scanner.api.ScannerForeground;
 import com.enioka.scanner.data.Barcode;
 import com.enioka.scanner.data.BarcodeType;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,10 +24,10 @@ public class GenericHidScanner implements ScannerForeground {
 
     private String keyboardInput = "";
     private boolean paused = false;
-    private ScannerDataCallback dataCb;
+    private ScannerDataCallbackProxy dataCb;
 
     @Override
-    public void initialize(Activity ctx, ScannerInitCallback initCallback, final ScannerDataCallback dataCallback, ScannerStatusCallback statusCallback, Mode mode) {
+    public void initialize(Activity ctx, ScannerInitCallbackProxy initCallback, final ScannerDataCallbackProxy dataCallback, ScannerStatusCallbackProxy statusCallback, Mode mode) {
         this.dataCb = dataCallback;
 
         // Register an OnKeyListener onto the Activity root view, if any.
@@ -73,7 +75,7 @@ public class GenericHidScanner implements ScannerForeground {
     }
 
     @Override
-    public void setDataCallBack(ScannerDataCallback cb) {
+    public void setDataCallBack(ScannerDataCallbackProxy cb) {
         this.dataCb = cb;
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
@@ -9,6 +9,9 @@ import com.enioka.scanner.api.ScannerBackground;
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 import com.enioka.scanner.bt.api.Scanner;
 import com.enioka.scanner.data.Barcode;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 import com.enioka.scanner.sdk.honeywelloss.commands.ActivateTrigger;
 import com.enioka.scanner.sdk.honeywelloss.commands.Beep;
 import com.enioka.scanner.sdk.honeywelloss.commands.DeactivateTrigger;
@@ -25,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 class HoneywellOssScanner implements ScannerBackground {
-    private ScannerDataCallback dataCallback = null;
+    private ScannerDataCallbackProxy dataCallback = null;
     private final Scanner btScanner;
 
     HoneywellOssScanner(Scanner btScanner) {
@@ -38,7 +41,7 @@ class HoneywellOssScanner implements ScannerBackground {
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void setDataCallBack(ScannerDataCallback cb) {
+    public void setDataCallBack(ScannerDataCallbackProxy cb) {
         this.dataCallback = cb;
     }
 
@@ -164,7 +167,7 @@ class HoneywellOssScanner implements ScannerBackground {
     }
 
     @Override
-    public void initialize(final Context applicationContext, final ScannerInitCallback initCallback, final ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
+    public void initialize(final Context applicationContext, final ScannerInitCallbackProxy initCallback, final ScannerDataCallbackProxy dataCallback, final ScannerStatusCallbackProxy statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
@@ -167,8 +167,6 @@ class HoneywellOssScanner implements ScannerBackground {
     public void initialize(final Context applicationContext, final ScannerInitCallback initCallback, final ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
-        final Handler uiHandler = new Handler(applicationContext.getMainLooper());
-
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
             public void onScannerConnected() {
@@ -193,12 +191,7 @@ class HoneywellOssScanner implements ScannerBackground {
             public void onSuccess(final Barcode data) {
                 final List<Barcode> res = new ArrayList<>(1);
                 res.add(data);
-                uiHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        HoneywellOssScanner.this.dataCallback.onData(HoneywellOssScanner.this, res);
-                    }
-                });
+                HoneywellOssScanner.this.dataCallback.onData(HoneywellOssScanner.this, res);
             }
 
             @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
@@ -1,7 +1,6 @@
 package com.enioka.scanner.sdk.postech;
 
 import android.content.Context;
-import android.os.Handler;
 
 import com.enioka.scanner.R;
 import com.enioka.scanner.api.Color;
@@ -42,8 +41,6 @@ class PostechSppScanner implements ScannerBackground {
     public void initialize(final Context applicationContext, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
-        final Handler uiHandler = new Handler(applicationContext.getMainLooper());
-
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
             public void onScannerConnected() {
@@ -68,12 +65,7 @@ class PostechSppScanner implements ScannerBackground {
             public void onSuccess(final Barcode data) {
                 final List<Barcode> res = new ArrayList<>(1);
                 res.add(data);
-                uiHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        PostechSppScanner.this.dataCallback.onData(PostechSppScanner.this, res);
-                    }
-                });
+                PostechSppScanner.this.dataCallback.onData(PostechSppScanner.this, res);
 
             }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
@@ -8,6 +8,9 @@ import com.enioka.scanner.api.ScannerBackground;
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 import com.enioka.scanner.bt.api.Scanner;
 import com.enioka.scanner.data.Barcode;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 import com.enioka.scanner.sdk.generalscan.commands.Bell;
 import com.enioka.scanner.sdk.generalscan.commands.CloseRead;
 import com.enioka.scanner.sdk.generalscan.commands.EnableBarcodeSuffix;
@@ -20,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 class PostechSppScanner implements ScannerBackground {
-    private ScannerDataCallback dataCallback = null;
+    private ScannerDataCallbackProxy dataCallback = null;
     private final Scanner btScanner;
 
     PostechSppScanner(Scanner btScanner) {
@@ -38,7 +41,7 @@ class PostechSppScanner implements ScannerBackground {
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void initialize(final Context applicationContext, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
+    public void initialize(final Context applicationContext, ScannerInitCallbackProxy initCallback, ScannerDataCallbackProxy dataCallback, final ScannerStatusCallbackProxy statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
@@ -89,7 +92,7 @@ class PostechSppScanner implements ScannerBackground {
     }
 
     @Override
-    public void setDataCallBack(ScannerDataCallback cb) {
+    public void setDataCallBack(ScannerDataCallbackProxy cb) {
         this.dataCallback = cb;
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -9,6 +9,9 @@ import com.enioka.scanner.api.ScannerBackground;
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 import com.enioka.scanner.bt.api.Scanner;
 import com.enioka.scanner.data.Barcode;
+import com.enioka.scanner.helpers.ScannerDataCallbackProxy;
+import com.enioka.scanner.helpers.ScannerInitCallbackProxy;
+import com.enioka.scanner.helpers.ScannerStatusCallbackProxy;
 import com.enioka.scanner.sdk.zebraoss.commands.Beep;
 import com.enioka.scanner.sdk.zebraoss.commands.LedOff;
 import com.enioka.scanner.sdk.zebraoss.commands.LedOn;
@@ -32,7 +35,7 @@ import java.util.concurrent.Semaphore;
 class ZebraOssScanner implements ScannerBackground {
     private static final String LOG_TAG = "SsiParser";
 
-    private ScannerDataCallback dataCallback = null;
+    private ScannerDataCallbackProxy dataCallback = null;
     private final com.enioka.scanner.bt.api.Scanner btScanner;
     private final Map<String, String> statusCache = new HashMap<>();
 
@@ -46,7 +49,7 @@ class ZebraOssScanner implements ScannerBackground {
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Override
-    public void setDataCallBack(ScannerDataCallback cb) {
+    public void setDataCallBack(ScannerDataCallbackProxy cb) {
         this.dataCallback = cb;
     }
 
@@ -182,7 +185,7 @@ class ZebraOssScanner implements ScannerBackground {
     }
 
     @Override
-    public void initialize(final Context applicationContext, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
+    public void initialize(final Context applicationContext, ScannerInitCallbackProxy initCallback, ScannerDataCallbackProxy dataCallback, final ScannerStatusCallbackProxy statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
         // Hook connection / disconnection events

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -1,7 +1,6 @@
 package com.enioka.scanner.sdk.zebraoss;
 
 import android.content.Context;
-import android.os.Handler;
 import android.util.Log;
 
 import com.enioka.scanner.R;
@@ -186,8 +185,6 @@ class ZebraOssScanner implements ScannerBackground {
     public void initialize(final Context applicationContext, ScannerInitCallback initCallback, ScannerDataCallback dataCallback, final ScannerStatusCallback statusCallback, Mode mode) {
         this.dataCallback = dataCallback;
 
-        final Handler uiHandler = new Handler(applicationContext.getMainLooper());
-
         // Hook connection / disconnection events
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
@@ -214,12 +211,7 @@ class ZebraOssScanner implements ScannerBackground {
             public void onSuccess(final Barcode data) {
                 final List<Barcode> res = new ArrayList<>(1);
                 res.add(data);
-                uiHandler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        ZebraOssScanner.this.dataCallback.onData(ZebraOssScanner.this, res);
-                    }
-                });
+                ZebraOssScanner.this.dataCallback.onData(ZebraOssScanner.this, res);
             }
 
             @Override


### PR DESCRIPTION
Resolves #36 
Deprecated by #60 

- Remove explicit jumps to ui thread from all SDKs and scanner classes
- Wrap jumps to ui tread in helper classes that encapsulate callbacks that may need it

Closed: #60 better refactors the code and integrates the many changes applied to master since this PR was opened.