### PR TITLE
Draft: Add high-level status changed callback

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/api/Scanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/Scanner.java
@@ -1,5 +1,7 @@
 package com.enioka.scanner.api;
 
+import android.support.annotation.Nullable;
+
 import com.enioka.scanner.data.Barcode;
 
 import java.util.List;
@@ -59,29 +61,50 @@ public interface Scanner {
         void onData(Scanner s, List<Barcode> data);
     }
 
-    @Deprecated
+    /**
+     * Callback to deal with scanner status changes.
+     */
     interface ScannerStatusCallback {
         /**
+         * Enum describing the scanner's lifecycle and current status.
+         * Some elements may not be used depending on which scanner SDK is used.
+         */
+        enum Status {
+            /** The scanner is waiting for a connection. */
+            WAITING,
+            /** The scanner is in the process of connecting. */
+            CONNECTING,
+            /** The scanner disconnected but is trying to reconnect. */
+            RECONNECTING,
+            /** The scanner has finished connecting. */
+            CONNECTED,
+            /** The scanner is in the process of initializing. */
+            INITIALIZING,
+            /** The scanner has finished initializing. */
+            INITIALIZED,
+            /** The scanner is ready to scan and waiting to be used. */
+            READY,
+            /** The scanner is in the process of scanning. */
+            SCANNING,
+            /** The scanner is connected, initialized and enabled but not ready to scan. */
+            IDLE,
+            /** The scanner is connected and initialized but has been disabled and cannot be used. */
+            DISABLED,
+            /** The scanner is no longer available after a critical error occurred, usually during connection or initialization. */
+            FAILURE,
+            /** The scanner disconnected and can no longer be used. */
+            DISCONNECTED,
+            /** The scanner is in an unknown status. */
+            UNKNOWN
+        }
+
+        /**
          * Called whenever the scanner has changed status.
-         *
-         * @param newStatus
+         * @param scanner The updated scanner. May be null if the scanner has not yet been created.
+         * @param newStatus The new status.
+         * @param statusDetails The associated status details.
          */
-        void onStatusChanged(String newStatus);
-
-        /**
-         * Called whenever a scanner was disconnected with hopes of reconnection. If reconnection fails, {@link #onScannerDisconnected(Scanner)} is called.
-         * Reconnection parameters depend on the SDK used.
-         *
-         * @param s the scanner
-         */
-        void onScannerReconnecting(Scanner s);
-
-        /**
-         * A scanner was disconnected with no hope of coming back to life.
-         *
-         * @param s the scanner
-         */
-        void onScannerDisconnected(Scanner s);
+        void onStatusChanged(@Nullable final Scanner scanner, final Status newStatus, final String statusDetails);
     }
 
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/Scanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/Scanner.java
@@ -59,6 +59,7 @@ public interface Scanner {
         void onData(Scanner s, List<Barcode> data);
     }
 
+    @Deprecated
     interface ScannerStatusCallback {
         /**
          * Called whenever the scanner has changed status.

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerStatus.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerStatus.java
@@ -7,6 +7,7 @@ package com.enioka.scanner.api;
 public interface ScannerStatus {
     /**
      * Enum describing the scanner's lifecycle and current status.
+     * Some elements may not make sense depending on which scanner SDK is used.
      */
     enum Status {
         /** The scanner is waiting for a connection. */
@@ -36,74 +37,109 @@ public interface ScannerStatus {
     }
 
     /**
-     * Gets the current status of a scanner.
-     * @return The scanner's status.
+     * Updates the status and its details before calling the appropriate callback.
+     * @param scanner The updated scanner.
+     * @param newStatus The new status.
+     * @param statusDetails The associated status details.
      */
-    Status getStatus();
-
-    /**
-     * Gets a more detailed overview of a scanner's status (may contain sdk-specific messages).
-     * @return The scanner's status details.
-     */
-    String getStatusDetails();
+    void onStatusChanged(final Scanner scanner, final Status newStatus, final String statusDetails);/* {
+        switch (newStatus) {
+            case WAITING:
+                onWaiting(scanner);
+                break;
+            case CONNECTING:
+                onConnecting(scanner);
+                break;
+            case RECONNECTING:
+                onReconnecting(scanner);
+                break;
+            case CONNECTED:
+                onConnected(scanner);
+                break;
+            case INITIALIZING:
+                onInitializing(scanner);
+                break;
+            case INITIALIZED:
+                onInitialized(scanner);
+                break;
+            case READY:
+                onReady(scanner);
+                break;
+            case SCANNING:
+                onScanning(scanner);
+                break;
+            case IDLE:
+                onIdle(scanner);
+                break;
+            case DISABLED:
+                onDisabled(scanner);
+                break;
+            case FAILURE:
+                onFailure(scanner);
+                break;
+            case DISCONNECTED:
+                onDisconnected(scanner);
+                break;
+        }
+    }*/
 
     /**
      * Callback used when the scanner is waiting for a connection.
      */
-    void onWaiting();
+    //void onWaiting(final Scanner scanner);
 
     /**
      * Callback used when the scanner is connecting.
      */
-    void onConnecting();
+    //void onConnecting(final Scanner scanner);
 
     /**
      * Callback used when the scanner is reconnecting.
      */
-    void onReconnecting();
+    //void onReconnecting(final Scanner scanner);
 
     /**
      * Callback used when the scanner is connected.
      */
-    void onConnected();
+    //void onConnected(final Scanner scanner);
 
     /**
      * Callback used when the scanner is initializing.
      */
-    void onInitializing();
+    //void onInitializing(final Scanner scanner);
 
     /**
      * Callback used when the scanner is initialized.
      */
-    void onInitialized();
+    //void onInitialized(final Scanner scanner);
 
     /**
      * Callback used when the scanner becomes ready to scan.
      */
-    void onReady();
+    //void onReady(final Scanner scanner);
 
     /**
      * Callback used when the scanner is scanning.
      */
-    void onScanning();
+    //void onScanning(final Scanner scanner);
 
     /**
      * Callback used when the scanner goes idle.
      */
-    void onIdle();
+    //void onIdle(final Scanner scanner);
 
     /**
      * Callback used when the scanner gets disabled.
      */
-    void onDisabled();
+    //void onDisabled(final Scanner scanner);
 
     /**
      * Callback used when a critical failure happens.
      */
-    void onFailure();
+    //void onFailure(final Scanner scanner);
 
     /**
      * Callback used when the scanner has disconnected.
      */
-    void onDisconnected();
+    //void onDisconnected(final Scanner scanner);
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerStatus.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerStatus.java
@@ -1,13 +1,17 @@
 package com.enioka.scanner.api;
 
+import android.support.annotation.Nullable;
+
 /**
+ * FIXME 21/02/2022 - Class kept as placeholder until it's decided whether individual callbacks are to be defined in it or by the user.
+ *                    Remove it if callbacks are not needed, remove Scanner.ScannerStatusCallback otherwise.
  * The interface to implement to describe a scanner's internal status and associated callbacks.
  * Replaces {@link Scanner.ScannerStatusCallback}.
  */
 public interface ScannerStatus {
     /**
      * Enum describing the scanner's lifecycle and current status.
-     * Some elements may not make sense depending on which scanner SDK is used.
+     * Some elements may not be used depending on which scanner SDK is used.
      */
     enum Status {
         /** The scanner is waiting for a connection. */
@@ -33,16 +37,18 @@ public interface ScannerStatus {
         /** The scanner is no longer available after a critical error occurred, usually during connection or initialization. */
         FAILURE,
         /** The scanner disconnected and can no longer be used. */
-        DISCONNECTED
+        DISCONNECTED,
+        /** The scanner is in an unknown status. */
+        UNKNOWN
     }
 
     /**
-     * Updates the status and its details before calling the appropriate callback.
-     * @param scanner The updated scanner.
+     * Called whenever the scanner has changed status.
+     * @param scanner The updated scanner. May be null if the scanner has not yet been created.
      * @param newStatus The new status.
      * @param statusDetails The associated status details.
      */
-    void onStatusChanged(final Scanner scanner, final Status newStatus, final String statusDetails);/* {
+    default void onStatusChanged(@Nullable final Scanner scanner, final Status newStatus, final String statusDetails) {
         switch (newStatus) {
             case WAITING:
                 onWaiting(scanner);
@@ -80,66 +86,73 @@ public interface ScannerStatus {
             case DISCONNECTED:
                 onDisconnected(scanner);
                 break;
+            default:
+                onUnknown(scanner);
         }
-    }*/
+    }
 
     /**
      * Callback used when the scanner is waiting for a connection.
      */
-    //void onWaiting(final Scanner scanner);
+    void onWaiting(final Scanner scanner);
 
     /**
      * Callback used when the scanner is connecting.
      */
-    //void onConnecting(final Scanner scanner);
+    void onConnecting(final Scanner scanner);
 
     /**
      * Callback used when the scanner is reconnecting.
      */
-    //void onReconnecting(final Scanner scanner);
+    void onReconnecting(final Scanner scanner);
 
     /**
      * Callback used when the scanner is connected.
      */
-    //void onConnected(final Scanner scanner);
+    void onConnected(final Scanner scanner);
 
     /**
      * Callback used when the scanner is initializing.
      */
-    //void onInitializing(final Scanner scanner);
+    void onInitializing(final Scanner scanner);
 
     /**
      * Callback used when the scanner is initialized.
      */
-    //void onInitialized(final Scanner scanner);
+    void onInitialized(final Scanner scanner);
 
     /**
      * Callback used when the scanner becomes ready to scan.
      */
-    //void onReady(final Scanner scanner);
+    void onReady(final Scanner scanner);
 
     /**
      * Callback used when the scanner is scanning.
      */
-    //void onScanning(final Scanner scanner);
+    void onScanning(final Scanner scanner);
 
     /**
      * Callback used when the scanner goes idle.
      */
-    //void onIdle(final Scanner scanner);
+    void onIdle(final Scanner scanner);
 
     /**
      * Callback used when the scanner gets disabled.
      */
-    //void onDisabled(final Scanner scanner);
+    void onDisabled(final Scanner scanner);
 
     /**
      * Callback used when a critical failure happens.
      */
-    //void onFailure(final Scanner scanner);
+    void onFailure(final Scanner scanner);
 
     /**
      * Callback used when the scanner has disconnected.
      */
-    //void onDisconnected(final Scanner scanner);
+    void onDisconnected(final Scanner scanner);
+
+    /**
+     * Callback used when the scanner enters an unknown status.
+     */
+    void onUnknown(final Scanner scanner);
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerStatus.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/api/ScannerStatus.java
@@ -1,0 +1,109 @@
+package com.enioka.scanner.api;
+
+/**
+ * The interface to implement to describe a scanner's internal status and associated callbacks.
+ * Replaces {@link Scanner.ScannerStatusCallback}.
+ */
+public interface ScannerStatus {
+    /**
+     * Enum describing the scanner's lifecycle and current status.
+     */
+    enum Status {
+        /** The scanner is waiting for a connection. */
+        WAITING,
+        /** The scanner is in the process of connecting. */
+        CONNECTING,
+        /** The scanner disconnected but is trying to reconnect. */
+        RECONNECTING,
+        /** The scanner has finished connecting. */
+        CONNECTED,
+        /** The scanner is in the process of initializing. */
+        INITIALIZING,
+        /** The scanner has finished initializing. */
+        INITIALIZED,
+        /** The scanner is ready to scan and waiting to be used. */
+        READY,
+        /** The scanner is in the process of scanning. */
+        SCANNING,
+        /** The scanner is connected, initialized and enabled but not ready to scan. */
+        IDLE,
+        /** The scanner is connected and initialized but has been disabled and cannot be used. */
+        DISABLED,
+        /** The scanner is no longer available after a critical error occurred, usually during connection or initialization. */
+        FAILURE,
+        /** The scanner disconnected and can no longer be used. */
+        DISCONNECTED
+    }
+
+    /**
+     * Gets the current status of a scanner.
+     * @return The scanner's status.
+     */
+    Status getStatus();
+
+    /**
+     * Gets a more detailed overview of a scanner's status (may contain sdk-specific messages).
+     * @return The scanner's status details.
+     */
+    String getStatusDetails();
+
+    /**
+     * Callback used when the scanner is waiting for a connection.
+     */
+    void onWaiting();
+
+    /**
+     * Callback used when the scanner is connecting.
+     */
+    void onConnecting();
+
+    /**
+     * Callback used when the scanner is reconnecting.
+     */
+    void onReconnecting();
+
+    /**
+     * Callback used when the scanner is connected.
+     */
+    void onConnected();
+
+    /**
+     * Callback used when the scanner is initializing.
+     */
+    void onInitializing();
+
+    /**
+     * Callback used when the scanner is initialized.
+     */
+    void onInitialized();
+
+    /**
+     * Callback used when the scanner becomes ready to scan.
+     */
+    void onReady();
+
+    /**
+     * Callback used when the scanner is scanning.
+     */
+    void onScanning();
+
+    /**
+     * Callback used when the scanner goes idle.
+     */
+    void onIdle();
+
+    /**
+     * Callback used when the scanner gets disabled.
+     */
+    void onDisabled();
+
+    /**
+     * Callback used when a critical failure happens.
+     */
+    void onFailure();
+
+    /**
+     * Callback used when the scanner has disconnected.
+     */
+    void onDisconnected();
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/helpers/intent/IntentScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/helpers/intent/IntentScanner.java
@@ -16,7 +16,6 @@ import com.enioka.scanner.data.BarcodeType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -77,7 +76,7 @@ public abstract class IntentScanner<BarcodeTypeClass> extends BroadcastReceiver 
         }
 
         if (this.statusCb != null) {
-            this.statusCb.onStatusChanged(ctx.getString(R.string.scanner_status_waiting));
+            this.statusCb.onStatusChanged(this, ScannerStatusCallback.Status.READY, ctx.getString(R.string.scanner_status_ready));
         }
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
@@ -47,19 +47,17 @@ class GsSppScanner implements ScannerBackground {
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
             public void onScannerConnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_connected));
+                statusCallback.onStatusChanged(GsSppScanner.this, ScannerStatusCallback.Status.CONNECTED, applicationContext.getString(R.string.scanner_status_connected));
             }
 
             @Override
             public void onScannerReconnecting() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_reconnecting));
-                statusCallback.onScannerReconnecting(GsSppScanner.this);
+                statusCallback.onStatusChanged(GsSppScanner.this, ScannerStatusCallback.Status.RECONNECTING, applicationContext.getString(R.string.scanner_status_reconnecting));
             }
 
             @Override
             public void onScannerDisconnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_lost));
-                statusCallback.onScannerDisconnected(GsSppScanner.this);
+                statusCallback.onStatusChanged(GsSppScanner.this, ScannerStatusCallback.Status.DISCONNECTED, applicationContext.getString(R.string.scanner_status_lost));
             }
         });
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
@@ -172,19 +172,17 @@ class HoneywellOssScanner implements ScannerBackground {
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
             public void onScannerConnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_connected));
+                statusCallback.onStatusChanged(HoneywellOssScanner.this, ScannerStatusCallback.Status.CONNECTED, applicationContext.getString(R.string.scanner_status_connected));
             }
 
             @Override
             public void onScannerReconnecting() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_reconnecting));
-                statusCallback.onScannerReconnecting(HoneywellOssScanner.this);
+                statusCallback.onStatusChanged(HoneywellOssScanner.this, ScannerStatusCallback.Status.RECONNECTING, applicationContext.getString(R.string.scanner_status_reconnecting));
             }
 
             @Override
             public void onScannerDisconnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_lost));
-                statusCallback.onScannerDisconnected(HoneywellOssScanner.this);
+                statusCallback.onStatusChanged(HoneywellOssScanner.this, ScannerStatusCallback.Status.DISCONNECTED, applicationContext.getString(R.string.scanner_status_lost));
             }
         });
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
@@ -47,19 +47,17 @@ class PostechSppScanner implements ScannerBackground {
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
             public void onScannerConnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_connected));
+                statusCallback.onStatusChanged(PostechSppScanner.this, ScannerStatusCallback.Status.CONNECTED, applicationContext.getString(R.string.scanner_status_connected));
             }
 
             @Override
             public void onScannerReconnecting() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_reconnecting));
-                statusCallback.onScannerReconnecting(PostechSppScanner.this);
+                statusCallback.onStatusChanged(PostechSppScanner.this, ScannerStatusCallback.Status.RECONNECTING, applicationContext.getString(R.string.scanner_status_reconnecting));
             }
 
             @Override
             public void onScannerDisconnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_lost));
-                statusCallback.onScannerDisconnected(PostechSppScanner.this);
+                statusCallback.onStatusChanged(PostechSppScanner.this, ScannerStatusCallback.Status.DISCONNECTED, applicationContext.getString(R.string.scanner_status_lost));
             }
         });
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/proglove/ProgloveScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/proglove/ProgloveScanner.java
@@ -136,7 +136,7 @@ public class ProgloveScanner extends IntentScanner<String> {
         Log.d(LOG_TAG, "Received status update from scanner " + status);
         switch (status) {
             case "RECONNECTING":
-                this.statusCb.onScannerReconnecting(this);
+                this.statusCb.onStatusChanged(this, ScannerStatusCallback.Status.RECONNECTING, status);
                 connected = false;
                 this.connectionAttempts++;
 
@@ -151,10 +151,10 @@ public class ProgloveScanner extends IntentScanner<String> {
                 break;
             case "ERROR":
             case "CONNECTING":
-                this.statusCb.onStatusChanged(status);
+                this.statusCb.onStatusChanged(this, ScannerStatusCallback.Status.CONNECTING, status);
                 break;
             case "CONNECTED":
-                this.statusCb.onStatusChanged(status);
+                this.statusCb.onStatusChanged(this, ScannerStatusCallback.Status.CONNECTED, status);
                 this.connected = true;
                 this.connectionAttempts = 0;
                 break;
@@ -173,7 +173,7 @@ public class ProgloveScanner extends IntentScanner<String> {
                 }
                 break;
             default:
-                this.statusCb.onStatusChanged("Unknown status " + status);
+                this.statusCb.onStatusChanged(this, ScannerStatusCallback.Status.UNKNOWN, "Unknown status " + status);
         }
     }
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -192,19 +192,17 @@ class ZebraOssScanner implements ScannerBackground {
         this.btScanner.registerStatusCallback(new Scanner.SppScannerStatusCallback() {
             @Override
             public void onScannerConnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_connected));
+                statusCallback.onStatusChanged(ZebraOssScanner.this, ScannerStatusCallback.Status.CONNECTED, applicationContext.getString(R.string.scanner_status_connected));
             }
 
             @Override
             public void onScannerReconnecting() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_reconnecting));
-                statusCallback.onScannerReconnecting(ZebraOssScanner.this);
+                statusCallback.onStatusChanged(ZebraOssScanner.this, ScannerStatusCallback.Status.RECONNECTING, applicationContext.getString(R.string.scanner_status_reconnecting));
             }
 
             @Override
             public void onScannerDisconnected() {
-                statusCallback.onStatusChanged(applicationContext.getString(R.string.scanner_status_lost));
-                statusCallback.onScannerDisconnected(ZebraOssScanner.this);
+                statusCallback.onStatusChanged(ZebraOssScanner.this, ScannerStatusCallback.Status.DISCONNECTED, applicationContext.getString(R.string.scanner_status_lost));
             }
         });
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/service/ScannerService.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/service/ScannerService.java
@@ -18,6 +18,7 @@ import com.enioka.scanner.api.ScannerBackground;
 import com.enioka.scanner.api.ScannerConnectionHandler;
 import com.enioka.scanner.api.ScannerForeground;
 import com.enioka.scanner.api.ScannerSearchOptions;
+import com.enioka.scanner.api.ScannerStatus;
 import com.enioka.scanner.data.Barcode;
 
 import java.util.ArrayList;
@@ -34,12 +35,22 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Note that the public API of this service is described in {@link ScannerServiceApi}, which the type obtained by binding to this service.
  * The other methods of this class should not be accessed by clients.
  */
-public class ScannerService extends Service implements ScannerConnectionHandler, Scanner.ScannerInitCallback, Scanner.ScannerDataCallback, Scanner.ScannerStatusCallback, ScannerServiceApi {
+public class ScannerService extends Service implements ScannerConnectionHandler, Scanner.ScannerInitCallback, Scanner.ScannerDataCallback, Scanner.ScannerStatusCallback, ScannerStatus, ScannerServiceApi {
 
     protected final static String LOG_TAG = "ScannerService";
 
     private Handler uiHandler;
     private boolean firstBind = true;
+
+    /**
+     * Scanner status
+     */
+    private ScannerStatus.Status scannerStatus = Status.DISCONNECTED;
+
+    /**
+     * Scanner status detailed information
+     */
+    private String scannerStatusDetails = "";
 
     /**
      * Scanner instances. They should never leak outside of this service.
@@ -408,5 +419,104 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
     @Override
     public List<Scanner> getConnectedScanners() {
         return scanners;
+    }
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    // SCANNER STATUS API
+    ////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public Status getStatus() {
+        return scannerStatus;
+    }
+
+    @Override
+    public String getStatusDetails() {
+        return scannerStatusDetails;
+    }
+
+    @Override
+    public void onWaiting() {
+        scannerStatus = Status.WAITING;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_listen);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onConnecting() {
+        scannerStatus = Status.CONNECTING;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_connecting);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onReconnecting() {
+        scannerStatus = Status.RECONNECTING;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_reconnecting);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onConnected() {
+        scannerStatus = Status.CONNECTED;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_connected);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onInitializing() {
+        scannerStatus = Status.INITIALIZING;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_initializing);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onInitialized() {
+        scannerStatus = Status.INITIALIZED;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_initialized);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onReady() {
+        scannerStatus = Status.READY;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_waiting);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onScanning() {
+        scannerStatus = Status.SCANNING;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_scanning);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onIdle() {
+        scannerStatus = Status.IDLE;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_idle);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onDisabled() {
+        scannerStatus = Status.DISABLED;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_disabled);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onFailure() {
+        scannerStatus = Status.FAILURE;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_initialization_failure); // Not the most appropriate message but close enough
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    }
+
+    @Override
+    public void onDisconnected() {
+        scannerStatus = Status.DISCONNECTED;
+        scannerStatusDetails = getResources().getString(R.string.scanner_status_lost);
+        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/service/ScannerService.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/service/ScannerService.java
@@ -43,16 +43,6 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
     private boolean firstBind = true;
 
     /**
-     * Scanner status
-     */
-    private ScannerStatus.Status scannerStatus = Status.DISCONNECTED;
-
-    /**
-     * Scanner status detailed information
-     */
-    private String scannerStatusDetails = "";
-
-    /**
      * Scanner instances. They should never leak outside of this service.
      */
     protected final List<Scanner> scanners = new ArrayList<>(10);
@@ -252,12 +242,9 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
     @Override
     public void onStatusChanged(final String newStatus) {
         Log.d(LOG_TAG, "Status change: " + newStatus);
-        uiHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                for (BackgroundScannerClient client : ScannerService.this.clients) {
-                    client.onStatusChanged(newStatus);
-                }
+        uiHandler.post(() -> {
+            for (BackgroundScannerClient client : ScannerService.this.clients) {
+                client.onStatusChanged(newStatus);
             }
         });
     }
@@ -426,97 +413,70 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
     // SCANNER STATUS API
     ////////////////////////////////////////////////////////////////////////////
 
+    /**
+     * This is temporary as currently there is no specific behavior for these callbacks.
+     * ScannerClient interfaces will need to be adapted to reflect these changes.
+     * @param scanner The updated scanner.
+     * @param newStatus The new status.
+     * @param statusDetails The associated status details.
+     */
     @Override
-    public Status getStatus() {
-        return scannerStatus;
+    public void onStatusChanged(final Scanner scanner, final Status newStatus, final String statusDetails) {
+        Log.d(LOG_TAG, "Status changed: " + newStatus.toString() + " --- " + statusDetails);
+        uiHandler.post(() -> {
+            for (BackgroundScannerClient client : ScannerService.this.clients) {
+                client.onStatusChanged(statusDetails);
+            }
+        });
+    }
+
+    /*
+    @Override
+    public void onWaiting(Scanner scanner) {
     }
 
     @Override
-    public String getStatusDetails() {
-        return scannerStatusDetails;
+    public void onConnecting(Scanner scanner) {
     }
 
     @Override
-    public void onWaiting() {
-        scannerStatus = Status.WAITING;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_listen);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onReconnecting(Scanner scanner) {
     }
 
     @Override
-    public void onConnecting() {
-        scannerStatus = Status.CONNECTING;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_connecting);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onConnected(Scanner scanner) {
     }
 
     @Override
-    public void onReconnecting() {
-        scannerStatus = Status.RECONNECTING;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_reconnecting);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onInitializing(Scanner scanner) {
     }
 
     @Override
-    public void onConnected() {
-        scannerStatus = Status.CONNECTED;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_connected);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onInitialized(Scanner scanner) {
     }
 
     @Override
-    public void onInitializing() {
-        scannerStatus = Status.INITIALIZING;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_initializing);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onReady(Scanner scanner) {
     }
 
     @Override
-    public void onInitialized() {
-        scannerStatus = Status.INITIALIZED;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_initialized);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onScanning(Scanner scanner) {
     }
 
     @Override
-    public void onReady() {
-        scannerStatus = Status.READY;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_waiting);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onIdle(Scanner scanner) {
     }
 
     @Override
-    public void onScanning() {
-        scannerStatus = Status.SCANNING;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_scanning);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onDisabled(Scanner scanner) {
     }
 
     @Override
-    public void onIdle() {
-        scannerStatus = Status.IDLE;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_idle);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onFailure(Scanner scanner) {
     }
 
     @Override
-    public void onDisabled() {
-        scannerStatus = Status.DISABLED;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_disabled);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
+    public void onDisconnected(Scanner scanner) {
     }
-
-    @Override
-    public void onFailure() {
-        scannerStatus = Status.FAILURE;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_initialization_failure); // Not the most appropriate message but close enough
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
-    }
-
-    @Override
-    public void onDisconnected() {
-        scannerStatus = Status.DISCONNECTED;
-        scannerStatusDetails = getResources().getString(R.string.scanner_status_lost);
-        Log.d(LOG_TAG, "Scanner changed status to " + scannerStatus.toString());
-    }
+    */
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/service/ScannerService.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/service/ScannerService.java
@@ -18,7 +18,6 @@ import com.enioka.scanner.api.ScannerBackground;
 import com.enioka.scanner.api.ScannerConnectionHandler;
 import com.enioka.scanner.api.ScannerForeground;
 import com.enioka.scanner.api.ScannerSearchOptions;
-import com.enioka.scanner.api.ScannerStatus;
 import com.enioka.scanner.data.Barcode;
 
 import java.util.ArrayList;
@@ -35,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Note that the public API of this service is described in {@link ScannerServiceApi}, which the type obtained by binding to this service.
  * The other methods of this class should not be accessed by clients.
  */
-public class ScannerService extends Service implements ScannerConnectionHandler, Scanner.ScannerInitCallback, Scanner.ScannerDataCallback, Scanner.ScannerStatusCallback, ScannerStatus, ScannerServiceApi {
+public class ScannerService extends Service implements ScannerConnectionHandler, Scanner.ScannerInitCallback, Scanner.ScannerDataCallback, Scanner.ScannerStatusCallback, ScannerServiceApi {
 
     protected final static String LOG_TAG = "ScannerService";
 
@@ -160,7 +159,7 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
 
     @Override
     public void scannerConnectionProgress(String providerKey, String scannerKey, String message) {
-        onStatusChanged(providerKey + " reports " + message);
+        onStatusChanged(null, Status.CONNECTING, providerKey + " reports " + message);
     }
 
     @Override
@@ -181,14 +180,14 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
 
     @Override
     public void noScannerAvailable() {
-        onStatusChanged(getResources().getString(R.string.scanner_service_no_compatible_sdk));
+        onStatusChanged(null, Status.FAILURE, getResources().getString(R.string.scanner_service_no_compatible_sdk));
         checkInitializationEnd();
     }
 
     @Override
     public void endOfScannerSearch() {
         Log.i(LOG_TAG, scanners.size() + " scanners from the different SDKs have reported for duty. Waiting for the initialization of the " + (scanners.size() - foregroundScanners.size()) + " background scanners.");
-        onStatusChanged(getResources().getString(R.string.scanner_service_sdk_search_end));
+        onStatusChanged(null, Status.FAILURE, getResources().getString(R.string.scanner_service_sdk_search_end));
         checkInitializationEnd();
     }
 
@@ -201,7 +200,7 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
     public void onConnectionSuccessful(Scanner s) {
         Log.i(LOG_TAG, "A scanner has successfully initialized from provider " + s.getProviderKey());
         this.scanners.add(s);
-        onStatusChanged(getResources().getString(R.string.scanner_status_initialized));
+        onStatusChanged(s, Status.CONNECTED, getResources().getString(R.string.scanner_status_initialized));
         initializingScannersCount.decrementAndGet();
         checkInitializationEnd();
     }
@@ -209,7 +208,7 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
     @Override
     public void onConnectionFailure(Scanner s) {
         Log.i(LOG_TAG, "A scanner has failed to initialize from provider " + s.getProviderKey());
-        onStatusChanged(getResources().getString(R.string.scanner_status_initialization_failure));
+        onStatusChanged(s, Status.FAILURE, getResources().getString(R.string.scanner_status_initialization_failure));
         initializingScannersCount.decrementAndGet();
         checkInitializationEnd();
     }
@@ -234,33 +233,6 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
         }
     }
 
-
-    ////////////////////////////////////////////////////////////////////////////
-    // BLAH BLAH HANDLERS
-    ////////////////////////////////////////////////////////////////////////////
-
-    @Override
-    public void onStatusChanged(final String newStatus) {
-        Log.d(LOG_TAG, "Status change: " + newStatus);
-        uiHandler.post(() -> {
-            for (BackgroundScannerClient client : ScannerService.this.clients) {
-                client.onStatusChanged(newStatus);
-            }
-        });
-    }
-
-    @Override
-    public void onScannerDisconnected(Scanner s) {
-        scanners.remove(s);
-        if (s instanceof ScannerForeground) {
-            foregroundScanners.remove(s);
-        }
-    }
-
-    @Override
-    public void onScannerReconnecting(Scanner s) {
-        // Nothing to do.
-    }
 
     ////////////////////////////////////////////////////////////////////////////
     // SCANNER DATA HANDLERS
@@ -410,24 +382,32 @@ public class ScannerService extends Service implements ScannerConnectionHandler,
 
 
     ////////////////////////////////////////////////////////////////////////////
-    // SCANNER STATUS API
+    // SCANNER STATUS CALLBACK
     ////////////////////////////////////////////////////////////////////////////
 
-    /**
-     * This is temporary as currently there is no specific behavior for these callbacks.
-     * ScannerClient interfaces will need to be adapted to reflect these changes.
-     * @param scanner The updated scanner.
-     * @param newStatus The new status.
-     * @param statusDetails The associated status details.
-     */
     @Override
-    public void onStatusChanged(final Scanner scanner, final Status newStatus, final String statusDetails) {
+    public void onStatusChanged(final Scanner scanner, final Scanner.ScannerStatusCallback.Status newStatus, final String statusDetails) {
         Log.d(LOG_TAG, "Status changed: " + newStatus.toString() + " --- " + statusDetails);
         uiHandler.post(() -> {
             for (BackgroundScannerClient client : ScannerService.this.clients) {
                 client.onStatusChanged(statusDetails);
             }
         });
+
+        switch (newStatus) {
+            case DISCONNECTED:
+                onScannerDisconnected(scanner);
+                break;
+            default:
+                //ignore
+        }
+    }
+
+    private void onScannerDisconnected(final Scanner scanner) {
+        scanners.remove(scanner);
+        if (scanner instanceof ScannerForeground) {
+            foregroundScanners.remove(scanner);
+        }
     }
 
     /*

--- a/enioka_scan/src/main/res/values-fr/strings.xml
+++ b/enioka_scan/src/main/res/values-fr/strings.xml
@@ -3,7 +3,7 @@
     <string name="scanner_status_disabled">Scanner désactivé</string>
     <string name="scanner_status_idle">Scanner au repos</string>
     <string name="scanner_status_scanning">Scanner actif</string>
-    <string name="scanner_status_waiting">Scanner en attente</string>
+    <string name="scanner_status_ready">Scanner en attente</string>
     <string name="scanner_camera_no_camera">Aucune caméra disponible. Veuillez brancher votre lecteur laser. L\'application va s\'arrêter.</string>
     <string name="scanner_camera_open_error">Veuillez vérifier qu\'aucune autre application n\'utilise la caméra (comme ScanWedge, DataWedge...). Vérifiez aussi que la caméra fnction dans l\'application idoine.</string>
     <string name="scanner_camera_open_error_title">Impossible de se connecter à la caméra</string>

--- a/enioka_scan/src/main/res/values/strings.xml
+++ b/enioka_scan/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <!-- Scanner status -->
     <string name="scanner_status_idle">Scanner is idle</string>
     <string name="scanner_status_scanning">Scanner is scanning</string>
-    <string name="scanner_status_waiting">Scanner ready to scan on trigger press</string>
+    <string name="scanner_status_ready">Scanner ready to scan on trigger press</string>
     <string name="scanner_status_disabled">Scanner is disabled</string>
     <string name="scanner_status_initialized">Scanner is correctly initialized</string>
     <string name="scanner_status_initializing">Scanner is initializing</string>

--- a/enioka_scan_honeywell/src/main/java/com/enioka/scanner/sdk/honeywell/AIDCScanner.java
+++ b/enioka_scan_honeywell/src/main/java/com/enioka/scanner/sdk/honeywell/AIDCScanner.java
@@ -94,7 +94,7 @@ public class AIDCScanner implements ScannerBackground, BarcodeReader.BarcodeList
         }
 
         if (this.statusCb != null) {
-            this.statusCb.onStatusChanged("Scanner is ready");
+            this.statusCb.onStatusChanged(this, ScannerStatusCallback.Status.READY, "Scanner is ready");
         }
         Log.i(LOG_TAG, "Scanner initialized");
 

--- a/enioka_scan_koamtac/src/main/java/com/enioka/scanner/sdk/koamtac/KoamtacScanner.java
+++ b/enioka_scan_koamtac/src/main/java/com/enioka/scanner/sdk/koamtac/KoamtacScanner.java
@@ -94,10 +94,12 @@ class KoamtacScanner implements ScannerBackground, KDCBarcodeDataReceivedListene
 
     @Override
     public void ConnectionChanged(BluetoothDevice bluetoothDevice, int i) {
-        String message = null;
+        final String message;
+        final ScannerStatusCallback.Status status;
         switch (i) {
             case KDCConstants.CONNECTION_STATE_CONNECTED:
                 message = this.ctx.getResources().getString(R.string.scanner_status_connected);
+                status = ScannerStatusCallback.Status.CONNECTED;
 
                 configureScanner();
                 if (initCallback != null) {
@@ -112,15 +114,19 @@ class KoamtacScanner implements ScannerBackground, KDCBarcodeDataReceivedListene
                 break;
             case KDCConstants.CONNECTION_STATE_CONNECTING:
                 message = this.ctx.getResources().getString(R.string.scanner_status_connecting);
+                status = ScannerStatusCallback.Status.CONNECTING;
                 break;
             case KDCConstants.CONNECTION_STATE_FAILED:
                 message = this.ctx.getResources().getString(R.string.scanner_status_initialization_failure);
+                status = ScannerStatusCallback.Status.FAILURE;
                 break;
             case KDCConstants.CONNECTION_STATE_INITIALIZING:
                 message = this.ctx.getResources().getString(R.string.scanner_status_initializing);
+                status = ScannerStatusCallback.Status.INITIALIZING;
                 break;
             case KDCConstants.CONNECTION_STATE_INITIALIZING_FAILED:
                 message = this.ctx.getResources().getString(R.string.scanner_status_initialization_failure);
+                status = ScannerStatusCallback.Status.FAILURE;
                 if (initCallback != null) {
                     new Handler(Looper.getMainLooper()).post(new Runnable() {
                         @Override
@@ -132,13 +138,17 @@ class KoamtacScanner implements ScannerBackground, KDCBarcodeDataReceivedListene
                 break;
             case KDCConstants.CONNECTION_STATE_LISTEN:
                 message = this.ctx.getResources().getString(R.string.scanner_status_listen);
+                status = ScannerStatusCallback.Status.WAITING;
                 break;
             case KDCConstants.CONNECTION_STATE_LOST:
                 message = this.ctx.getResources().getString(R.string.scanner_status_lost);
+                status = ScannerStatusCallback.Status.DISCONNECTED;
                 break;
             case KDCConstants.CONNECTION_STATE_NONE:
+            default:
                 // Not doing anything.
                 message = null; // this.ctx.getResources().getString(R.string.scanner_status_unknown);
+                status = ScannerStatusCallback.Status.UNKNOWN;
                 break;
         }
 
@@ -146,12 +156,11 @@ class KoamtacScanner implements ScannerBackground, KDCBarcodeDataReceivedListene
             return;
         }
 
-        final String msg2 = message;
         if (this.statusCallback != null) {
             new Handler(Looper.getMainLooper()).post(new Runnable() {
                 @Override
                 public void run() {
-                    statusCallback.onStatusChanged(msg2);
+                    statusCallback.onStatusChanged(KoamtacScanner.this, status, message);
                 }
             });
         }

--- a/enioka_scan_m3/src/main/java/com/enioka/scanner/sdk/m3/M3RingScanner.java
+++ b/enioka_scan_m3/src/main/java/com/enioka/scanner/sdk/m3/M3RingScanner.java
@@ -116,13 +116,13 @@ class M3RingScanner implements ScannerBackground {
 
     @Override
     public void pause() {
-        statusCallback.onStatusChanged(context.getString(com.enioka.scanner.R.string.scanner_status_disabled));
+        statusCallback.onStatusChanged(this, ScannerStatusCallback.Status.DISABLED, context.getString(com.enioka.scanner.R.string.scanner_status_disabled));
         this.scanner.setReadable(false);
     }
 
     @Override
     public void resume() {
-        statusCallback.onStatusChanged(context.getString(com.enioka.scanner.R.string.scanner_status_waiting));
+        statusCallback.onStatusChanged(this, ScannerStatusCallback.Status.READY, context.getString(com.enioka.scanner.R.string.scanner_status_ready));
         this.scanner.setReadable(true);
     }
 

--- a/enioka_scan_zebra/src/main/java/com/enioka/scanner/sdk/zebra/BtZebraScanner.java
+++ b/enioka_scan_zebra/src/main/java/com/enioka/scanner/sdk/zebra/BtZebraScanner.java
@@ -92,14 +92,13 @@ class BtZebraScanner implements ScannerBackground {
 
     void reconnected() {
         if (statusCb != null) {
-            statusCb.onScannerReconnecting(this);
-            statusCb.onStatusChanged("reconnected");
+            statusCb.onStatusChanged(this, ScannerStatusCallback.Status.CONNECTED, "reconnected");
         }
     }
 
     void disconnected() {
         if (statusCb != null) {
-            statusCb.onScannerReconnecting(this);
+            statusCb.onStatusChanged(this, ScannerStatusCallback.Status.DISCONNECTED, "disconnected");
         }
     }
 

--- a/enioka_scan_zebra/src/main/java/com/enioka/scanner/sdk/zebra/EmdkZebraScanner.java
+++ b/enioka_scan_zebra/src/main/java/com/enioka/scanner/sdk/zebra/EmdkZebraScanner.java
@@ -105,7 +105,7 @@ public class EmdkZebraScanner implements ScannerBackground, EMDKManager.EMDKList
 
         // Toast to indicate that the user can now start scanning
         if (statusCb != null) {
-            statusCb.onStatusChanged("Press Hard Scan Button to start scanning...");
+            statusCb.onStatusChanged(this, ScannerStatusCallback.Status.READY, "Press Hard Scan Button to start scanning...");
         }
     }
 
@@ -256,7 +256,7 @@ public class EmdkZebraScanner implements ScannerBackground, EMDKManager.EMDKList
 
                 // Scanner is waiting for trigger press
                 case WAITING:
-                    statusStr = r.getString(R.string.scanner_status_waiting);
+                    statusStr = r.getString(R.string.scanner_status_ready);
                     break;
 
                 // Scanner is not enabled
@@ -275,7 +275,7 @@ public class EmdkZebraScanner implements ScannerBackground, EMDKManager.EMDKList
         @Override
         protected void onPostExecute(String result) {
             if (statusCb != null) {
-                statusCb.onStatusChanged(result);
+                statusCb.onStatusChanged(selfScanner, ScannerStatusCallback.Status.UNKNOWN, result);
             }
         }
 


### PR DESCRIPTION
Resolves #32 

* Rework `Scanner.ScannerStatusCallback` interface to enforce specific enum values rather than random strings, making tracking and processing of status changes more streamlined across the board.

Draft: requires API validation, need to decide between keeping `Scanner.ScannerStatusCallback` or `ScannerStatus`.