### PR TITLE
Fix workflow triggers and clarify release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/create-release@v1
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ steps.get_version.outputs.VERSION }}
+          release_name: ${{ steps.get_version.outputs.VERSION }}
           draft: false
           prerelease: false
           files: enioka_scan/build/outputs/aar/enioka_scan-release.aar

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  create:
-    tags: '*'
-    branches: master
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    tags-ignore:
+    branches:
       - '*'
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [ push ]
+on:
+  push:
+    tags-ignore:
+      - '*'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -180,3 +180,9 @@ In order to start developing and testing the library:
 In case the android device is not detected by Android Studio:
 * Make sure the device is in developer mode and has USB Debugging enabled
 * Make sure the USB cable supports data transfer (some cables only support charging)
+
+# Release process
+
+To publish the library to Maven Central and GitHub releases, a tag must be created and attached to the appropriate commit.
+The tag will trigger a workflow that will automatically create a github release containing the AAR file, and publish the library to Maven Central.
+If the release is created manually, the workflow will not run and the library will not be published correctly. Only the tag needs to be manually created.


### PR DESCRIPTION
* Fix release workflow trigger: no longer triggers on branch creation or pushes to master
* Fix release naming: now `<tag name>` instead of `Release <tag name>`
* Fix test workflow trigger: no longer triggers on tag pushes (release workflow already contains a test step, no need for duplication)
* Clarify release process in `README.md`: requires manual tag creation only, does not work with manual release creation