### PR TITLE
#62 - Add provider filtering for BT providers

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/LaserScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/LaserScanner.java
@@ -12,6 +12,7 @@ import com.enioka.scanner.api.Scanner;
 import com.enioka.scanner.api.ScannerConnectionHandler;
 import com.enioka.scanner.api.ScannerProvider;
 import com.enioka.scanner.api.ScannerSearchOptions;
+import com.enioka.scanner.bt.manager.SerialBtScannerProvider;
 import com.enioka.scanner.helpers.BtScannerConnectionRegistry;
 import com.enioka.scanner.helpers.ProviderServiceHolder;
 import com.enioka.scanner.helpers.ProviderServiceMeta;
@@ -136,6 +137,14 @@ public final class LaserScanner {
      * @param options parameters for scanner search.
      */
     public static void getLaserScanner(final Context ctx, final ScannerConnectionHandler handler, final ScannerSearchOptions options) {
+        // Removing the BtSppSdk provider, as it is already handled by the useBluetooth option.
+        if (options.allowedProviderKeys != null) {
+            options.allowedProviderKeys.remove(SerialBtScannerProvider.PROVIDER_NAME);
+        }
+        if (options.excludedProviderKeys != null) {
+            options.excludedProviderKeys.remove(SerialBtScannerProvider.PROVIDER_NAME);
+        }
+
         if (providerServices.isEmpty()) {
             getProviders(ctx, () -> startLaserSearchInProviders(ctx, handler, options));
         } else {

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/api/BtSppScannerProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/api/BtSppScannerProvider.java
@@ -14,6 +14,13 @@ public interface BtSppScannerProvider {
     void canManageDevice(Scanner device, ManagementCallback callback);
 
     /**
+     * The unique key which identifies this provider.
+     *
+     * @return the key
+     */
+    String getKey();
+
+    /**
      * The {@link ScannerDataParser} which should be used to parse results.
      */
     ScannerDataParser getInputHandler();

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/athesi/HHTProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/athesi/HHTProvider.java
@@ -10,7 +10,7 @@ import com.enioka.scanner.helpers.intent.IntentScannerProvider;
  * Provider for the HHT Wrapper Layer
  */
 public class HHTProvider extends IntentScannerProvider {
-    static final String PROVIDER_NAME = "Athesi HHT internal scanner";
+    public static final String PROVIDER_NAME = "AthesiHHTProvider";
 
     @Override
     protected void configureProvider() {

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/bluebird/BluebirdProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/bluebird/BluebirdProvider.java
@@ -10,7 +10,7 @@ import com.enioka.scanner.helpers.intent.IntentScannerProvider;
  * Provider for Bluebird integrated scanners through an intent service.
  */
 public class BluebirdProvider extends IntentScannerProvider {
-    static final String PROVIDER_NAME = "BluebirdProvider";
+    public static final String PROVIDER_NAME = "BluebirdProvider";
 
     @Override
     protected void configureProvider() {

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScanner.java
@@ -29,7 +29,7 @@ class GsSppScanner implements ScannerBackground {
 
     @Override
     public String getProviderKey() {
-        return "BtSppSdk";
+        return GsSppScannerProvider.PROVIDER_NAME;
     }
 
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScannerProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/generalscan/GsSppScannerProvider.java
@@ -13,6 +13,7 @@ import com.enioka.scanner.sdk.generalscan.commands.OpenRead;
 import com.enioka.scanner.sdk.generalscan.data.DeviceId;
 
 public class GsSppScannerProvider implements BtSppScannerProvider {
+    public static final String PROVIDER_NAME = "BT_GeneralScanProvider";
 
     @Override
     public void canManageDevice(final Scanner device, final ManagementCallback callback) {
@@ -34,6 +35,11 @@ public class GsSppScannerProvider implements BtSppScannerProvider {
                 callback.cannotManage();
             }
         });
+    }
+
+    @Override
+    public String getKey() {
+        return PROVIDER_NAME;
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidProvider.java
@@ -8,21 +8,21 @@ import com.enioka.scanner.api.ScannerProvider;
 import com.enioka.scanner.api.ScannerSearchOptions;
 
 public class GenericHidProvider implements ScannerProvider {
-    static final String LOG_TAG = "GenericHidProvider";
+    static final String PROVIDER_NAME = "GenericHidProvider";
 
     @Override
     public void getScanner(Context ctx, ProviderCallback cb, ScannerSearchOptions options) {
         if (ctx.getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS) {
             // We may have a BT keyboard connected
-            Log.i(LOG_TAG, "A BT keyboard seems to be connected");
+            Log.i(PROVIDER_NAME, "A BT keyboard seems to be connected");
 
-            cb.onScannerCreated(LOG_TAG, "HID", new GenericHidScanner());
+            cb.onScannerCreated(PROVIDER_NAME, "HID", new GenericHidScanner());
         }
-        cb.onAllScannersCreated(LOG_TAG);
+        cb.onAllScannersCreated(PROVIDER_NAME);
     }
 
     @Override
     public String getKey() {
-        return LOG_TAG;
+        return PROVIDER_NAME;
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/hid/GenericHidScanner.java
@@ -160,6 +160,6 @@ public class GenericHidScanner implements ScannerForeground {
 
     @Override
     public String getProviderKey() {
-        return GenericHidProvider.LOG_TAG;
+        return GenericHidProvider.PROVIDER_NAME;
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssScanner.java
@@ -173,7 +173,7 @@ class HoneywellOssScanner implements ScannerBackground {
 
     @Override
     public String getProviderKey() {
-        return "BtSppSdk";
+        return HoneywellOssSppScannerProvider.PROVIDER_NAME;
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssSppScannerProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/honeywelloss/HoneywellOssSppScannerProvider.java
@@ -10,6 +10,7 @@ import com.enioka.scanner.sdk.honeywelloss.data.FirmwareVersion;
 import com.enioka.scanner.sdk.honeywelloss.parsers.HoneywellOssParser;
 
 public class HoneywellOssSppScannerProvider implements BtSppScannerProvider {
+    public static final String PROVIDER_NAME = "BT_HoneywellOssProvider";
 
     private final ScannerDataParser inputHandler = new HoneywellOssParser();
 
@@ -17,6 +18,11 @@ public class HoneywellOssSppScannerProvider implements BtSppScannerProvider {
     public void canManageDevice(final Scanner device, final ManagementCallback callback) {
         device.runCommand(new Cleanup(), null);
         testFirmwareCommand(device, callback);
+    }
+
+    @Override
+    public String getKey() {
+        return PROVIDER_NAME;
     }
 
     private void testFirmwareCommand(final Scanner device, final ManagementCallback callback) {

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScanner.java
@@ -30,7 +30,7 @@ class PostechSppScanner implements ScannerBackground {
 
     @Override
     public String getProviderKey() {
-        return "BtSppSdk";
+        return PostechSppScannerProvider.PROVIDER_NAME;
     }
 
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScannerProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/postech/PostechSppScannerProvider.java
@@ -12,6 +12,7 @@ import com.enioka.scanner.sdk.postech.commands.GetDeviceName;
 import com.enioka.scanner.sdk.postech.data.DeviceName;
 
 public class PostechSppScannerProvider implements BtSppScannerProvider {
+    public static final String PROVIDER_NAME = "BT_PostechProvider";
 
     @Override
     public void canManageDevice(final Scanner device, final ManagementCallback callback) {
@@ -34,6 +35,11 @@ public class PostechSppScannerProvider implements BtSppScannerProvider {
             }
         });
         //device.runCommand(new OpenRead(), null);
+    }
+
+    @Override
+    public String getKey() {
+        return PROVIDER_NAME;
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/proglove/ProgloveProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/proglove/ProgloveProvider.java
@@ -10,7 +10,7 @@ import com.enioka.scanner.helpers.intent.IntentScannerProvider;
  * Provider for Bluebird integrated scanners through an intent service.
  */
 public class ProgloveProvider extends IntentScannerProvider {
-    static final String PROVIDER_NAME = "ProgloveProvider";
+    public static final String PROVIDER_NAME = "ProgloveProvider";
 
     @Override
     protected void configureProvider() {

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssAttScannerProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssAttScannerProvider.java
@@ -8,6 +8,7 @@ import com.enioka.scanner.sdk.zebraoss.commands.CapabilitiesRequest;
 import com.enioka.scanner.sdk.zebraoss.data.CapabilitiesReply;
 
 public class ZebraOssAttScannerProvider implements BtSppScannerProvider {
+    private static final String PROVIDER_KEY = "BT_ZebraOssATTProvider";
     private final ScannerDataParser inputHandler = new SsiOverAttParser();
 
     @Override
@@ -18,7 +19,7 @@ public class ZebraOssAttScannerProvider implements BtSppScannerProvider {
         device.runCommand(new CapabilitiesRequest(), new DataSubscriptionCallback<CapabilitiesReply>() {
             @Override
             public void onSuccess(CapabilitiesReply data) {
-                callback.canManage(new ZebraOssScanner(device));
+                callback.canManage(new ZebraOssScanner(PROVIDER_KEY, device));
             }
 
             @Override
@@ -31,6 +32,11 @@ public class ZebraOssAttScannerProvider implements BtSppScannerProvider {
                 callback.cannotManage();
             }
         });
+    }
+
+    @Override
+    public String getKey() {
+        return PROVIDER_KEY;
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssScanner.java
@@ -39,8 +39,10 @@ class ZebraOssScanner implements ScannerBackground {
     private ScannerDataCallback dataCallback = null;
     private final com.enioka.scanner.bt.api.Scanner btScanner;
     private final Map<String, String> statusCache = new HashMap<>();
+    private final String providerKey;
 
-    ZebraOssScanner(com.enioka.scanner.bt.api.Scanner btScanner) {
+    ZebraOssScanner(final String providerKey, com.enioka.scanner.bt.api.Scanner btScanner) {
+        this.providerKey = providerKey;
         this.btScanner = btScanner;
     }
 
@@ -197,7 +199,7 @@ class ZebraOssScanner implements ScannerBackground {
 
     @Override
     public String getProviderKey() {
-        return "BtSppSdk";
+        return providerKey;
     }
 
     @Override

--- a/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssSppScannerProvider.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/sdk/zebraoss/ZebraOssSppScannerProvider.java
@@ -8,6 +8,7 @@ import com.enioka.scanner.sdk.zebraoss.commands.CapabilitiesRequest;
 import com.enioka.scanner.sdk.zebraoss.data.CapabilitiesReply;
 
 public class ZebraOssSppScannerProvider implements BtSppScannerProvider {
+    public static final String PROVIDER_KEY = "BT_ZebraOssSPPProvider";
     private final ScannerDataParser inputHandler = new SsiOverSppParser();
 
     @Override
@@ -18,7 +19,7 @@ public class ZebraOssSppScannerProvider implements BtSppScannerProvider {
         device.runCommand(new CapabilitiesRequest(), new DataSubscriptionCallback<CapabilitiesReply>() {
             @Override
             public void onSuccess(CapabilitiesReply data) {
-                callback.canManage(new ZebraOssScanner(device));
+                callback.canManage(new ZebraOssScanner(PROVIDER_KEY, device));
             }
 
             @Override
@@ -31,6 +32,11 @@ public class ZebraOssSppScannerProvider implements BtSppScannerProvider {
                 callback.cannotManage();
             }
         });
+    }
+
+    @Override
+    public String getKey() {
+        return PROVIDER_KEY;
     }
 
     @Override


### PR DESCRIPTION
Resolves #62 

* Add `getKey()` method for bluetooth scanner providers
* Make `PROVIDER_KEY` static attribute public for every scanner provider (bluetooth or not), allowing for any end user to use them directly when preparing their options, making it easier to get the provider names right
* Allow bluetooth providers in `ScannerSearchOptions` allowed/excluded providers lists, remove the default Bluetooth Provider from accepted entries (already handled by `useBluetooth option`)