### PR TITLE
Refactor com.enioka.scanner.bt package

### DIFF
--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/README.md
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/README.md
@@ -7,6 +7,9 @@ The library provides a small SDK to help creating connectors to most Bluetooth (
 It is centered on devices which use the SPP (Serial Port Profile) BT profile - the case for most if not all evolved BT scanners (while simple/cheap BT scanners are most often dumb HID/keyboards without SPP).
 Note that most devices that are MFi-certified (Made For iOS) are also SPP compatible.
 
+It also offers a compatibility layer for BLE (Bluetooth Low Energy, also called Bluetooth Smart or sometimes abusively Bluetooth 4.0) devices which actually encapsulate an older serial protocol inside BLE GATT attributes.
+Again, this is the case for most evolved BT scanners - manufacturers went the easiest route when switching from BT classic to BLE and did not redesign their decades old protocols.
+
 All the connection details are handled by the SDK, and the connector simply has to deal with the specific protocol needed by a device category, using a set of provided interfaces.
 This protocol is usually described inside the integration documentation or the programming guide of their respective devices.
 
@@ -17,7 +20,7 @@ So instead of using this generic SDK, it is simpler to just create a connector u
 
 However:
 * Most vendor SDK (perhaps even all?) are rather OSS unfriendly and just cannot be redistributed or even linked to.
-* Vendor SDK tend to consider they are alone in the world, notably when using the Bluetooth manager, while a point of eniokascan is to allow the use of multiple devices from multiple vendors without thinking twice about it.
+* Vendor SDK tend to consider they are alone in the world, notably when using the Bluetooth manager, while a point of this library is to allow the use of multiple devices from multiple vendors without thinking twice about it.
 * Many mid-priced devices actually have incomplete/limiting SDKs, even for the rather small needs of this library.
 
 Therefore, a generic BT SDK was created. Note however that the connectors made using this SDK will likely be compatible with less devices than those created from vendor SDK.
@@ -26,7 +29,7 @@ Therefore, a generic BT SDK was created. Note however that the connectors made u
 
 Coming soon(TM).
 
-For now, the SDK only deals with BT slave devices which are already paired with the Android device, and master devices.
+For now, the SDK only deals with BT slave devices which are already paired with the Android device, as well as master devices.
 
 ## Device discovery process
 
@@ -34,7 +37,7 @@ On startup, the library lists all BT provider services. A provider implements Bt
 
 ### Slave devices (Android opens the connection to the scanners)
 
-It then lists all BT slave devices which are already paired and feature the SPP BT service.
+It then lists all BT slave devices which are already paired and feature the SPP BT service in their BT descriptors.
 
 It connects to each one. Devices which fail to connect are ignored.
 
@@ -53,8 +56,8 @@ In both cases, the connector is responsible for identifying if it can handle a B
 
 * Metadata
   * MAC address: all BT interface vendors have a dedicated MAC prefix, which can be found [here](https://www.adminsub.net/mac-address-finder/). But this is often not reliable at all, for the scanner vendors all use the same BT interface providers. For example, the RS-6000 from Zebra uses a Texas Instrument interface, which can also be found in some Honeywell devices... Also, different generations of the same device may not use the same BT interface.
-  * BT services. All BT services are also prefixed! Prefixes can be found [here](https://www.bluetooth.com/specifications/assigned-numbers/16-bit-uuids-for-members/). The issue here is that most of the time the devices only advertise the SPP service. But if there are vendor-specific services available, this is quite reliable.
-  * Naming conventions on the BT device name, like a name prefix. In that case, the connector must provide a way to parameter the convention. As this has impacts on daily usability, this is a last resort.
+  * BT services. All BT services are also prefixed! Prefixes can be found [here](https://www.bluetooth.com/specifications/assigned-numbers/16-bit-uuids-for-members/). The issue here is that most of the time the devices only advertise the SPP service. But if there are vendor-specific services available (as is very often the case in BLE), this is quite reliable.
+  * Naming conventions on the BT device name, like a name prefix. In that case, the connector must provide a way to parameter the convention. As this has impacts on daily usability (need to pre-configure scanners with a compatible name), this is a last resort.
 * Commands
   * All devices have specific commands (and giving a simple API to them is the very goal of this library!). So trying to run a command, like "give me your model and version", available on most devices, is often the best way to discriminate between devices. That being said:
     * remember to always set a low timeout for detection commands - on a wrong device, the detection commands will likely do not return anything at all, and certainly not the expected end of answer delimitor.

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/api/Helpers.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/api/Helpers.java
@@ -1,7 +1,8 @@
 package com.enioka.scanner.bt.api;
 
-public class Helpers {
-    private static final String LOG_TAG = "BtSppSdk";
+public final class Helpers {
+
+    private Helpers(){}
 
     public static String byteArrayToHex(byte[] buffer, int length) {
         return byteArrayToHex(buffer, 0, length);

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/ScannerProviderResolutionThread.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/ScannerProviderResolutionThread.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import com.enioka.scanner.api.Scanner;
 import com.enioka.scanner.bt.api.BtSppScannerProvider;
+import com.enioka.scanner.bt.manager.common.BluetoothScannerInternal;
 
 import java.util.List;
 import java.util.concurrent.Semaphore;
@@ -16,9 +17,9 @@ import java.util.concurrent.Semaphore;
 class ScannerProviderResolutionThread implements Runnable, BtSppScannerProvider.ManagementCallback {
     private static final String LOG_TAG = "BtSppSdk";
 
-    private BluetoothScannerInternal device;
-    private List<BtSppScannerProvider> scannerProviders;
-    private ScannerResolutionCallback callback;
+    private final BluetoothScannerInternal device;
+    private final List<BtSppScannerProvider> scannerProviders;
+    private final ScannerResolutionCallback callback;
     private final Semaphore providerLock = new Semaphore(0);
     private Scanner foundLibraryScanner;
 
@@ -43,6 +44,13 @@ class ScannerProviderResolutionThread implements Runnable, BtSppScannerProvider.
         void notCompatible(BluetoothScannerInternal device);
     }
 
+    /**
+     * Create a new resolver for a given BT device (Classic or BLE).
+     *
+     * @param device           a connected device, ready to run commands.
+     * @param scannerProviders the list of BT scanner providers against which to check the compatibility of device.
+     * @param callback         what to do when resolution is done or failed
+     */
     ScannerProviderResolutionThread(BluetoothScannerInternal device, List<BtSppScannerProvider> scannerProviders, ScannerResolutionCallback callback) {
         this.device = device;
         this.scannerProviders = scannerProviders;

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleDeviceScanner.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleDeviceScanner.java
@@ -1,0 +1,95 @@
+package com.enioka.scanner.bt.manager.bleserial;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanFilter;
+import android.bluetooth.le.ScanResult;
+import android.bluetooth.le.ScanSettings;
+import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.support.annotation.RequiresApi;
+import android.util.Log;
+
+import com.enioka.scanner.bt.manager.common.BluetoothScannerInternal;
+import com.enioka.scanner.bt.manager.common.OnConnectedCallback;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class BleDeviceScanner {
+    private static final String LOG_TAG = "BtSppSdk";
+
+    // Common connection status codes. https://android.googlesource.com/platform/external/bluetooth/bluedroid/+/refs/heads/master/stack/include/gatt_api.h
+    // 00 = programmatically disconnected
+    // 08 = device out of range
+    // 19 0x13 = disconnected by device/ connection terminate by peer user
+    // 22 = issue with bond
+    // 62 = device not found
+    // 133 = device not found.
+
+    public static void get(final Context ctx) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            internalGet(ctx);
+        }
+    }
+
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    private static void internalGet(final Context ctx) {
+        if (!BleHelpers.isBleSupported(ctx)) {
+            return;
+        }
+
+        final BluetoothManager bluetoothManager = (BluetoothManager) ctx.getSystemService(Context.BLUETOOTH_SERVICE);
+        final BluetoothAdapter bluetoothAdapter = bluetoothManager.getAdapter();
+
+        final HashSet<String> foundDevices = new HashSet<>();
+
+        // We do NOT filter during scan - this is way too buggy on Android. We must filter on returned devices.
+        List<ScanFilter> filters = new ArrayList<>();
+        ScanSettings scanSettings = new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_BALANCED).build();
+
+        final BluetoothLeScanner leScanner = bluetoothAdapter.getBluetoothLeScanner();
+        final ScanCallback callback = new ScanCallback() {
+            @Override
+            public void onScanResult(int callbackType, ScanResult result) {
+                final BluetoothDevice btDevice = result.getDevice();
+                if (btDevice == null) {
+                    return;
+                }
+                if (foundDevices.contains(btDevice.getAddress())) {
+                    return; // Doubles can appear on some devices.
+                }
+                foundDevices.add(btDevice.getAddress());
+                Log.i(LOG_TAG, "A new BT device was returned. Start of analysis: is it a usable BLE device? " + btDevice.getName() + " - " + btDevice.getAddress());
+
+                BleTerminalIODevice device = new BleTerminalIODevice(ctx, btDevice);
+                device.connect(new OnConnectedCallback() {
+                    @Override
+                    public void connected(BluetoothScannerInternal scanner) {
+
+                    }
+
+                    @Override
+                    public void failed() {
+
+                    }
+                });
+
+            }
+        };
+        leScanner.startScan(filters, scanSettings, callback);
+
+        // Stop scan handler quickly (it is very battery-intensive - so we only allow a 10s scan)
+        Handler handler = new Handler();
+        handler.postDelayed(() -> {
+            Log.i(LOG_TAG, "End of BLE search");
+            leScanner.stopScan(callback);
+        }, 10000);
+    }
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleHelpers.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleHelpers.java
@@ -1,104 +1,20 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.bleserial;
 
 import android.bluetooth.BluetoothAdapter;
-import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.bluetooth.BluetoothManager;
-import android.bluetooth.le.BluetoothLeScanner;
-import android.bluetooth.le.ScanCallback;
-import android.bluetooth.le.ScanFilter;
-import android.bluetooth.le.ScanResult;
-import android.bluetooth.le.ScanSettings;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.os.Build;
-import android.os.Handler;
-import android.support.annotation.RequiresApi;
 import android.util.Log;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.UUID;
 
-class BleHelpers {
+public class BleHelpers {
     private static final String LOG_TAG = "BtSppSdk";
-
-    // Common connection status codes. https://android.googlesource.com/platform/external/bluetooth/bluedroid/+/refs/heads/master/stack/include/gatt_api.h
-    // 00 = programmatically disconnected
-    // 08 = device out of range
-    // 19 0x13 = disconnected by device/ connection terminate by peer user
-    // 22 = issue with bond
-    // 62 = device not found
-    // 133 = device not found.
-
-    public static void get(final Context ctx) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            internalGet(ctx);
-        }
-    }
-
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    private static void internalGet(final Context ctx) {
-        if (!isBleSupported(ctx)) {
-            return;
-        }
-
-        final BluetoothManager bluetoothManager = (BluetoothManager) ctx.getSystemService(Context.BLUETOOTH_SERVICE);
-        final BluetoothAdapter bluetoothAdapter = bluetoothManager.getAdapter();
-
-        final HashSet<String> foundDevices = new HashSet<>();
-
-        // We do NOT filter during scan - this is way too buggy on Android. We must filter on returned devices.
-        List<ScanFilter> filters = new ArrayList<>();
-        ScanSettings scanSettings = new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_BALANCED).build();
-
-        final BluetoothLeScanner leScanner = bluetoothAdapter.getBluetoothLeScanner();
-        final ScanCallback callback = new ScanCallback() {
-            @Override
-            public void onScanResult(int callbackType, ScanResult result) {
-                final BluetoothDevice btDevice = result.getDevice();
-                if (btDevice == null) {
-                    return;
-                }
-                if (foundDevices.contains(btDevice.getAddress())) {
-                    return;
-                }
-                foundDevices.add(btDevice.getAddress());
-                Log.i(LOG_TAG, "A new BT device was returned. Start of analysis: is it a usable BLE device? " + btDevice.getName() + " - " + btDevice.getAddress());
-
-                BleTerminalIODevice device = new BleTerminalIODevice(ctx, btDevice);
-                device.connect(new ClassicBtConnectToDeviceThread.OnConnectedCallback() {
-                    @Override
-                    public void connected(BluetoothScannerInternal scanner) {
-
-                    }
-
-                    @Override
-                    public void failed() {
-
-                    }
-                });
-
-            }
-        };
-        leScanner.startScan(filters, scanSettings, callback);
-
-        // Stop scan handler quickly (it is very battery-intensive)
-        Handler handler = new Handler();
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                Log.i(LOG_TAG, "End of BLE search");
-                leScanner.stopScan(callback);
-            }
-        }, 10000);
-    }
 
     private static void enableNotification(BluetoothGatt gatt, UUID characteristicId, BleSubscriptionType type) {
         BluetoothGattService service = gatt.getService(GattAttribute.TERMINAL_IO_SERVICE.id);
@@ -148,6 +64,12 @@ class BleHelpers {
         Log.d(LOG_TAG, "End of services for device " + gatt.getDevice().getName());
     }
 
+    /**
+     * Check if the system has a BLE adapter AND if it is enabled. Does not check for permissions.
+     *
+     * @param ctx a valid context
+     * @return true if BLE is ready to use
+     */
     static boolean isBleSupported(final Context ctx) {
         if (!ctx.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
             return false;

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleStateMachineDevice.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleStateMachineDevice.java
@@ -1,10 +1,10 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.bleserial;
 
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 
 /**
- * Some devices can actually be seen as state machines, modified on specific stimuli. This interface factors his behaviour.
+ * Some devices can actually be seen as state machines, modified on specific stimuli. This interface factors this behaviour.
  */
 public interface BleStateMachineDevice {
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleStateMachineGattCallback.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleStateMachineGattCallback.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.bleserial;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleSubscriptionType.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleSubscriptionType.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.bleserial;
 
 public enum BleSubscriptionType {
     NOTIFICATION,

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleTerminalIOStreamWriter.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/BleTerminalIOStreamWriter.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.bleserial;
 
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/GattAttribute.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/GattAttribute.java
@@ -1,8 +1,7 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.bleserial;
 
 import java.util.UUID;
 
-@SuppressWarnings("unused")
 public enum GattAttribute {
     /////////////////////////////////////////////
     // Standardized attributes

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/GattAttributeType.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/GattAttributeType.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.bleserial;
 
 public enum GattAttributeType {
     CHARACTERISTIC,

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/package-info.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/bleserial/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Most BLE scanners are actually using some sort of serial emulation instead of using GATT attributes as they were intended.
+ * This allows device constructors to re-use their existing proprietary serial protocols and have the same logic in BLE or Classic mode.
+ * This package contains utilities to help present a BLE device as a stream.
+ */
+package com.enioka.scanner.bt.manager.bleserial;

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtAcceptConnectionThread.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtAcceptConnectionThread.java
@@ -1,31 +1,35 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.classicserial;
 
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
 import android.util.Log;
 
+import com.enioka.scanner.bt.manager.SerialBtScannerProvider;
+import com.enioka.scanner.bt.manager.common.OnConnectedCallback;
+import com.enioka.scanner.bt.manager.common.BtConstHelpers;
+
 import java.io.IOException;
 
 /**
  * A SPP service listener thread on a bluetooth adapter. Used by master BT devices to connect to the phone. Closes after the first connection (OK or not). No timeout.
  */
-class ClassicBtAcceptConnectionThread extends Thread {
+public class ClassicBtAcceptConnectionThread extends Thread {
     private static final String LOG_TAG = "BtSppSdk";
 
     private final BluetoothServerSocket serverSocket;
-    private final ClassicBtConnectToDeviceThread.OnConnectedCallback onConnectedCallback;
+    private final OnConnectedCallback onConnectedCallback;
     private final SerialBtScannerProvider parentProvider;
 
     private boolean done = false;
 
-    ClassicBtAcceptConnectionThread(BluetoothAdapter bluetoothAdapter, ClassicBtConnectToDeviceThread.OnConnectedCallback callback, SerialBtScannerProvider parentProvider) {
+    public ClassicBtAcceptConnectionThread(BluetoothAdapter bluetoothAdapter, OnConnectedCallback callback, SerialBtScannerProvider parentProvider) {
         this.onConnectedCallback = callback;
         this.parentProvider = parentProvider;
 
         BluetoothServerSocket serverSocket = null;
         try {
-            serverSocket = bluetoothAdapter.listenUsingRfcommWithServiceRecord("SPP", ClassicBtConnectToDeviceThread.SERVER_BT_SERVICE_UUID);
+            serverSocket = bluetoothAdapter.listenUsingRfcommWithServiceRecord("SPP", BtConstHelpers.SERVER_BT_SERVICE_UUID);
         } catch (IOException e) {
             Log.e(LOG_TAG, "Socket's create() method failed", e);
         }
@@ -63,7 +67,7 @@ class ClassicBtAcceptConnectionThread extends Thread {
     }
 
     // Closes the client socket and causes the thread to finish.
-    void cancel() {
+    public void cancel() {
         try {
             this.serverSocket.close();
         } catch (IOException e) {
@@ -71,7 +75,7 @@ class ClassicBtAcceptConnectionThread extends Thread {
         }
     }
 
-    boolean isDone() {
+    public boolean isDone() {
         return this.done;
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtConnectToDeviceThread.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtConnectToDeviceThread.java
@@ -1,36 +1,23 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.classicserial;
 
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothSocket;
 import android.util.Log;
 
+import com.enioka.scanner.bt.manager.common.BtConstHelpers;
+
 import java.io.IOException;
-import java.util.UUID;
 
 /**
  * A thread which attempts (once) to connect to a given Classic BT SPP slave device.
+ * This is only a BT connection, without any applicative (level 7) stuff. This is the socket opening - streams are opened later by another component!
  */
-class ClassicBtConnectToDeviceThread extends Thread {
+public class ClassicBtConnectToDeviceThread extends Thread {
     private static final String LOG_TAG = "BtSppSdk";
-
-    // This is the SPP service UUID. From http://sviluppomobile.blogspot.com/2012/11/bluetooth-services-uuids.html
-    static final UUID SERVER_BT_SERVICE_UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
 
     private BluetoothSocket clientSocket;
     private final BluetoothDevice bluetoothDevice;
     private final OnStreamConnectedCallback onConnectedCallback;
-
-    interface OnConnectedCallback {
-        void connected(BluetoothScannerInternal scanner);
-
-        void failed();
-    }
-
-    interface OnStreamConnectedCallback {
-        void connected(BluetoothSocket bluetoothSocket);
-
-        void failed();
-    }
 
     ClassicBtConnectToDeviceThread(BluetoothDevice bluetoothDevice, OnStreamConnectedCallback callback) {
         this.onConnectedCallback = callback;
@@ -39,7 +26,7 @@ class ClassicBtConnectToDeviceThread extends Thread {
 
     public void run() {
         try {
-            this.clientSocket = bluetoothDevice.createRfcommSocketToServiceRecord(SERVER_BT_SERVICE_UUID);
+            this.clientSocket = bluetoothDevice.createRfcommSocketToServiceRecord(BtConstHelpers.SERVER_BT_SERVICE_UUID);
         } catch (IOException e) {
             Log.e(LOG_TAG, "Socket's create() method failed", e);
             this.onConnectedCallback.failed();

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtSocketStreamReader.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtSocketStreamReader.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.classicserial;
 
 import android.util.Log;
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtSocketStreamWriter.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtSocketStreamWriter.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.classicserial;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtSocketStreamWriterTask.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/ClassicBtSocketStreamWriterTask.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.classicserial;
 
 import android.util.Log;
 

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/OnStreamConnectedCallback.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/classicserial/OnStreamConnectedCallback.java
@@ -1,0 +1,12 @@
+package com.enioka.scanner.bt.manager.classicserial;
+
+import android.bluetooth.BluetoothSocket;
+
+/**
+ * Called when a stream has failed or succeeded to connect.
+ */
+interface OnStreamConnectedCallback {
+    void connected(BluetoothSocket bluetoothSocket);
+
+    void failed();
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/BluetoothScannerInternal.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/BluetoothScannerInternal.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.common;
 
 import com.enioka.scanner.bt.api.BtSppScannerProvider;
 import com.enioka.scanner.bt.api.BluetoothScanner;
@@ -7,7 +7,7 @@ import com.enioka.scanner.bt.api.BluetoothScanner;
  * An abstraction used internally to address the different kinds of BT devices (BLE TIO, classic)
  */
 public interface BluetoothScannerInternal extends BluetoothScanner {
-    void connect(final ClassicBtConnectToDeviceThread.OnConnectedCallback callback);
+    void connect(final OnConnectedCallback callback);
 
     void setProvider(BtSppScannerProvider provider);
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/BtConstHelpers.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/BtConstHelpers.java
@@ -1,13 +1,27 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.common;
 
 import android.bluetooth.BluetoothClass;
 import android.bluetooth.BluetoothDevice;
 
+import java.util.UUID;
+
 /**
  * Log helpers.
  */
-class BtConstHelpers {
-    static String getBtClassDescription(int btClass) {
+public class BtConstHelpers {
+
+    /**
+     * This is the SPP service UUID. From http://sviluppomobile.blogspot.com/2012/11/bluetooth-services-uuids.html
+     **/
+    public static final UUID SERVER_BT_SERVICE_UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
+
+    /**
+     * Mostly for debugging/logging purposes. Translates a given BT ID in int form into a string.
+     *
+     * @param btClass the int ID of the BT class
+     * @return a normalized string description for this class or "UNKNOWN".
+     */
+    public static String getBtClassDescription(int btClass) {
         switch (btClass) {
             case BluetoothClass.Device.AUDIO_VIDEO_CAMCORDER:
                 return "AUDIO_VIDEO_CAMCORDER";
@@ -114,7 +128,13 @@ class BtConstHelpers {
         }
     }
 
-    static String getBtMajorClassDescription(int btMajorClass) {
+    /**
+     * Mostly for debugging/logging purposes. Translates a given BT ID in int form into a string.
+     *
+     * @param btMajorClass the int ID of the BT device major class.
+     * @return a normalized string description for this device major class or "UNKNOWN".
+     */
+    public static String getBtMajorClassDescription(int btMajorClass) {
         switch (btMajorClass) {
             case BluetoothClass.Device.Major.AUDIO_VIDEO:
                 return "AUDIO_VIDEO";
@@ -143,7 +163,13 @@ class BtConstHelpers {
         }
     }
 
-    static String getBondStateDescription(int bondState) {
+    /**
+     * Mostly for debugging/logging purposes. Translates a given BT ID in int form into a string.
+     *
+     * @param bondState the int ID of the BT device bond state.
+     * @return a normalized string description for this bond state or "UNKNOWN".
+     */
+    public static String getBondStateDescription(int bondState) {
         switch (bondState) {
             case BluetoothDevice.BOND_BONDED:
                 return "BONDED";

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/DataSubscription.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/DataSubscription.java
@@ -1,4 +1,4 @@
-package com.enioka.scanner.bt.manager;
+package com.enioka.scanner.bt.manager.common;
 
 import com.enioka.scanner.bt.api.DataSubscriptionCallback;
 
@@ -7,12 +7,12 @@ import java.util.Calendar;
 /**
  * Helper class storing execution context for callbacks on parsed data.
  */
-class DataSubscription {
+public class DataSubscription {
     private final DataSubscriptionCallback<?> callback;
     private Calendar timeOut = null;
     private final boolean permanent;
 
-    DataSubscription(DataSubscriptionCallback<?> callback, int timeOutMs, boolean permanent) {
+    public DataSubscription(DataSubscriptionCallback<?> callback, int timeOutMs, boolean permanent) {
         this.callback = callback;
         this.permanent = permanent;
 
@@ -22,7 +22,7 @@ class DataSubscription {
         }
     }
 
-    boolean isTimedOut() {
+    public boolean isTimedOut() {
         return this.timeOut != null && this.timeOut.before(Calendar.getInstance());
     }
 
@@ -30,7 +30,7 @@ class DataSubscription {
         return callback;
     }
 
-    boolean isPermanent() {
+    public boolean isPermanent() {
         return this.permanent;
     }
 }

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/OnConnectedCallback.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/OnConnectedCallback.java
@@ -1,0 +1,10 @@
+package com.enioka.scanner.bt.manager.common;
+
+/**
+ * A callback used when a device has succeeded or failed to connect.
+ */
+public interface OnConnectedCallback {
+    void connected(BluetoothScannerInternal scanner);
+
+    void failed();
+}

--- a/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/SerialBtScannerPassiveConnectionManager.java
+++ b/enioka_scan/src/main/java/com/enioka/scanner/bt/manager/common/SerialBtScannerPassiveConnectionManager.java
@@ -1,0 +1,23 @@
+package com.enioka.scanner.bt.manager.common;
+
+import android.bluetooth.BluetoothAdapter;
+
+/**
+ * Some scanners connect as masters onto the slave Android device.
+ * This means the Android device must have an open listener.
+ * This interface provides callback for providers to influence this listener lifecycle.
+ */
+public interface SerialBtScannerPassiveConnectionManager {
+    /**
+     * Signals the provider that all passive connection listeners must be restarted. Used to allow reconnection of a master device in case of accidental disconnection.
+     *
+     * @param bluetoothAdapter
+     */
+    void resetListener(BluetoothAdapter bluetoothAdapter);
+
+    /**
+     * Signal the provider that it is no longer necessary to keep passive connection listeners open.
+     * This is called when a master device has successfully connected - in this case the BT listener should be closed as it is a battery hog.
+     */
+    void stopMasterListener();
+}


### PR DESCRIPTION
Refactor the `com.enioka.scanner.bt` package by reorganizing classes and more clearly separating Classic BT from BT Low Energy.

Basically https://github.com/enioka/enioka_scan/tree/ble but more up-to-date with the current repository (the old branch was too disconnected to easily update).